### PR TITLE
Correct broken mysql_query (Pr/71 on old resources module)

### DIFF
--- a/resources/install/install.php
+++ b/resources/install/install.php
@@ -61,7 +61,7 @@ if ($step == "3"){
                         $sql_file = "protected/install.sql";
                         
                         // Assign the charset to specials chars
-                        mysql_query("SET NAMES 'utf8'");
+                        $link->query("SET NAMES 'utf8'");
                         
 						if (!file_exists($test_sql_file)) {
 							$errorMessage[] = "Could not open sql file: " . $test_sql_file . ".  If this file does not exist you must download new install files.";


### PR DESCRIPTION
When I try to install this module, I am getting the error "Fatal error: Call to undefined function mysql_query() in /var/www/html/resources/install/install.php on line 64"

I suspect this was broken by 26ae17c which changes a lot of mysql_query calls, and also the commit message says "not yet tested"
