### PR TITLE
Database connection error in Resources

### DIFF
--- a/resources/admin/classes/common/DatabaseObject.php
+++ b/resources/admin/classes/common/DatabaseObject.php
@@ -53,6 +53,10 @@ class DatabaseObject extends DynamicObject {
 
 		$this->primaryKey = $arguments->primaryKey;
 		$this->db = new DBService;
+
+		$arguments->setDefaultValueForArgumentName('db',false);
+		$this->db = $arguments->db ? $arguments->db : new DBService;
+
 		$this->defineRelationships();
 		//$this->defineAttributes();  //now performed in load
 		$this->overridePrimaryKeyName();

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -145,8 +145,9 @@ class Resource extends DatabaseObject {
 			$object = new ResourceRelationship(new NamedArguments(array('primaryKey' => $result['resourceRelationshipID'])));
 			array_push($objects, $object);
 		}else{
+			$db = new DBService;
 			foreach ($result as $row) {
-				$object = new ResourceRelationship(new NamedArguments(array('primaryKey' => $row['resourceRelationshipID'])));
+				$object = new ResourceRelationship(new NamedArguments(array('primaryKey' => $row['resourceRelationshipID'],'db'=>$db)));
 				array_push($objects, $object);
 			}
 		}


### PR DESCRIPTION
implements fix from May 11, 2015 in usage module allowing for use of single database connection when generating related resource lists. There was an error for too many database connections if the parent and child resources numbered over 140.