### PR TITLE
Licensing: Fix capitalization problem

### DIFF
--- a/licensing/admin/classes/domain/Expression.php
+++ b/licensing/admin/classes/domain/Expression.php
@@ -82,7 +82,7 @@ class Expression extends DatabaseObject {
 	//returns array of qualifier objects
 	public function getQualifiers(){
 
-		$query = "SELECT Qualifier.* FROM Qualifier, ExpressionQualifierProfile EQP where EQP.QualifierID = Qualifier.QualifierID AND expressionID = '" . $this->expressionID . "'";
+		$query = "SELECT Qualifier.* FROM Qualifier, ExpressionQualifierProfile EQP where EQP.qualifierID = Qualifier.qualifierID AND expressionID = '" . $this->expressionID . "'";
 
 		$result = $this->db->processQuery($query, 'assoc');
 


### PR DESCRIPTION
MySQL appears to be case insensitive, so capitalization doesn't matter in this case. BUT this is not true of every database platforms, so if we hope to support other platforms someday, this case needs to be fixed. Also, inconsistent capitalization makes the code confusing and may lead to bugs.