### PR TITLE
fix syntax error in mysqli_select_db in usage/install/install.php

### DIFF
--- a/usage/install/install.php
+++ b/usage/install/install.php
@@ -142,7 +142,7 @@ if ($step == "3"){
 		}else{
 
 			//next check that the database exists
-			$dbcheck = @mysqli_select_db("$database_name");
+			$dbcheck = @mysqli_select_db($link, "$database_name");
 			if (!$dbcheck) {
 				$errorMessage[] = "Unable to access the database '" . $database_name . "'.  Please verify it has been created.<br />MySQL Error: " . mysqli_error($link);
 			}else{


### PR DESCRIPTION
Leaving out the $link param on line 145 makes the call fail, but the error message on
screen (from line 147) shows a blank MySQL message, since there was no error with the
$link itself.

Without this change, installing the usage module fails in PHP 5.5.9.