### PR TITLE
Exit after redirecting to login screen

### DIFF
--- a/licensing/user.php
+++ b/licensing/user.php
@@ -55,7 +55,7 @@ $sessionID = $util->getSessionCookie();
 
 		$authURL = $util->getCORALURL() . "auth/" . $addURL . htmlentities($_SERVER['REQUEST_URI']);
 		header('Location: ' . $authURL, true);
-
+		exit("Redirecting to " . $authURL);
 	}
 
 

--- a/management/user.php
+++ b/management/user.php
@@ -55,7 +55,7 @@ $sessionID = $util->getSessionCookie();
 
 		$authURL = $util->getCORALURL() . "auth/" . $addURL . htmlentities($_SERVER['REQUEST_URI']);
 		header('Location: ' . $authURL, true);
-
+		exit("Redirecting to ". $authURL);
 	}
 
 

--- a/organizations/user.php
+++ b/organizations/user.php
@@ -57,7 +57,7 @@ if ($config->settings->authModule == 'Y'){
 
 		$authURL = $util->getCORALURL() . "auth/" . $addURL . htmlentities($_SERVER['REQUEST_URI']);
 		header('Location: ' . $authURL, true);
-
+		exit("Redirecting to ". $authURL);
 	}
 
 

--- a/resources/user.php
+++ b/resources/user.php
@@ -52,7 +52,7 @@ if ($config->settings->authModule == 'Y'){
 
 		$authURL = $util->getCORALURL() . "auth/" . $addURL . htmlentities($_SERVER['REQUEST_URI']);
 		header('Location: ' . $authURL, true);
-
+		exit("redirecting to " . $authURL);
 	}
 
 

--- a/usage/user.php
+++ b/usage/user.php
@@ -56,7 +56,7 @@ if ($config->settings->authModule == 'Y'){
 
 		$authURL = $util->getCORALURL() . "auth/" . $addURL . htmlentities($_SERVER['REQUEST_URI']);
 		header('Location: ' . $authURL, true);
-
+		exit("Redirecting to ". $authURL);
 	}
 
 


### PR DESCRIPTION
Once it has been determined that a user needs to login before proceeding, stop executing PHP
code, in case the client does not respect Location headers by default (such as curl).

Resolves Issue #32 .

Applied to resources, licensing, organizations, management and usage modules.