### PR TITLE
Remove extraneous SQL from update script

### DIFF
--- a/resources/install/protected/update_NEXT.sql
+++ b/resources/install/protected/update_NEXT.sql
@@ -1,10 +1,3 @@
-DROP TABLE IF EXISTS `AuthorizedSite`;
-CREATE TABLE  `AuthorizedSite` (
-  `authorizedSiteID` int(11) NOT NULL auto_increment,
-  `shortName` varchar(45) default NULL,
-  PRIMARY KEY  (`authorizedSiteID`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
-
 ALTER TABLE 'ResourcePayment'
 	ADD `includeStats` boolean default NULL;
 


### PR DESCRIPTION
This commit removes SQL from the upgrade script that creates an already existing table (after also dropping it, which would lose existing data). Those lines were probably included accidentally.