### PR TITLE
Resources: Fixes for modal size/placement on shorter viewports

### DIFF
--- a/resources/css/thickbox.css
+++ b/resources/css/thickbox.css
@@ -57,7 +57,7 @@
 	display:none;
 	border: 4px solid #525252;
 	text-align:left;
-	top:50%;
+	top:40%;
 	left:50%;
 	width: auto !important;
 }
@@ -112,15 +112,47 @@ margin-top: expression(0 - parseInt(this.offsetHeight / 2) + (TBWindowMargin = d
 	overflow:auto;
 	text-align:left;
 	line-height:1.4em;
-	height: auto !important;
-	width: auto !important;
+	width: auto;
+	min-height: 780px;
 }
+
+
+@media (max-height: 1000px) {
+	#TB_window {
+		top: 300px;
+		max-height: 700px;
+		overflow-y: auto;
+	}
+
+}
+
+@media (max-height: 700px) {
+	#TB_window {
+		max-height: 400px;
+	}
+
+	#TB_ajaxContent {
+		min-height: inherit;
+	}
+}
+
+@media (max-height: 400px) {
+	#TB_window {
+		max-height: 300px;
+	}
+
+	#TB_ajaxContent {
+		min-height: inherit;
+	}
+
+}
+
 
 #TB_ajaxContent.TB_modal{
 	padding:5px;
-	width: auto !important;
-	height: auto !important;
 }
+
+
 
 #TB_ajaxContent p{
 	padding:5px 0px 5px 0px;


### PR DESCRIPTION
The 'New Resource' form has a lot of inputs and the modal window wouldn't allow scrolling, which led to the submit/cancel buttons being unreachable on viewports with smaller vertical heights.

- Added media queries to optimize the placement of the modal based on the height of the client's viewport

- Removed the !important(s) that were preventing the vertical overflow property from functioning as intended.

> 
Using !important is bad practice and should be avoided because it makes debugging more difficult by breaking the natural cascading in your stylesheets.

https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity

https://css-tricks.com/when-using-important-is-the-right-choice/
