### PR TITLE
add missing closing php tag

### DIFF
--- a/management/index.php
+++ b/management/index.php
@@ -280,13 +280,10 @@ $_SESSION['ref_script']=$currentPage;
   if (($_SESSION['license_orderBy']) && ($reset != 'Y')){
 	  echo "orderBy = \"" . $_SESSION['license_orderBy'] . "\";";
   }
-
-
+?>
 </script>
 
 
 <?php
 include 'templates/footer.php';
 ?>
-
-


### PR DESCRIPTION
For some reason the php 5.6 parser was fine with this.
But the PHP 7 parse was throwing a parse error