### PR TITLE
fix break that should have been converted to a return

### DIFF
--- a/resources/ajax_processing/checkUploadAttachment.php
+++ b/resources/ajax_processing/checkUploadAttachment.php
@@ -7,7 +7,7 @@
 
 	if (!is_writable("attachments")) {
 		echo 3;
-		break;
+		return;
 	}
 
 


### PR DESCRIPTION
It's a syntax error for the PHP 7 parser (but not for the 5.6 one...)
It came from there:
https://github.com/Coral-erm/Coral/commit/137c9fd3fa3ce1e348fe1551dca8ef4662ced8be#diff-72bd8d1f368642e7efcbee7099f52c26L671
But when it was extracted to the current file it should have been
replaced by a return to prevent the rest from executing.