### PR TITLE
management: new doc form: fix unclosed <select> that broke error message

### DIFF
--- a/management/ajax_forms.php
+++ b/management/ajax_forms.php
@@ -159,6 +159,7 @@ switch ($_GET['action']) {
 								</select>
 <?php
 		}catch(Exception $e){
+			echo "</select>";
 			echo "				<span style='color:red'>" . _("There was an error processing this request - please verify configuration.ini is set up for organizations correctly and the database and tables have been created.") . "</span>";
 		}
 ?>


### PR DESCRIPTION
Before, the error message was in the HTML code but not visible.

![before](https://cloud.githubusercontent.com/assets/2678215/16523889/fa764932-3fa5-11e6-9c81-5f04861bd2f3.png)

Now:
![after](https://cloud.githubusercontent.com/assets/2678215/16524013/8733fbb2-3fa6-11e6-9464-f5817cc490bf.png)