### PR TITLE
resources: fix undefined offset: don't try to regex an empty string

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1292,6 +1292,9 @@ class Resource extends DatabaseObject {
 		$additional_joins = array();
 
 		foreach($conditional_joins as $join) {
+			// drop the last line of $conditional_joins which is empty
+			if (trim($join) == "") { break; }
+
 			$match = array();
 			preg_match("/[A-Z]+(?= ON )/i", $join, $match);
 			$table_name = $match[0];


### PR DESCRIPTION
I got an `Undefined offset: 0`  when it was doing the `$match[0];` on the result.
After having thought that it could be a problem it turns out to be just the [last line of $conditional_joins](https://github.com/tuxayo/Coral/blob/d10e038a02057b6076fa084aaa2dd8126398afd6/resources/admin/classes/domain/Resource.php#L1290) that was causing the last element to be `""`

Nothing really problematic beside the Notice, so while I'm at it, here is a fix.