### PR TITLE
resources: fix isbnOrISSN that was assigned '' instead of []

### DIFF
--- a/resources/ajax_processing/submitNewResource.php
+++ b/resources/ajax_processing/submitNewResource.php
@@ -28,7 +28,7 @@
 
 		$resource->titleText 			= $_POST['titleText'];
 		$resource->descriptionText 		= $_POST['descriptionText'];
-		$resource->isbnOrISSN	 		= '';
+		$resource->isbnOrISSN	 		= [];
 		$resource->statusID		 		= $statusID;
 		$resource->orderNumber	 		= '';
 		$resource->systemNumber 		= '';


### PR DESCRIPTION
Ressource::setIsbnOrIssn expects an array and sending a ' ' was making the
foreach unhappy.

https://github.com/Coral-erm/Coral/blob/9398f2d413be7dea644a1e59eabd0bba6d4dc8f4/resources/admin/classes/domain/Resource.php#L2457
https://github.com/Coral-erm/Coral/blob/90af125b8aa56645496caddef0f65161f34268a6/resources/import.php#L395
https://github.com/Coral-erm/Coral/blob/82e99ed032cb7b5066d04040238d611cae1275ea/resources/ajax_processing/submitProductUpdate.php#L18

