### PR TITLE
Move session_start() out of class definition

### DIFF
--- a/resources/install/CORALInstaller.php
+++ b/resources/install/CORALInstaller.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require_once('../directory.php');
 
 if (!function_exists('debug')) {
@@ -8,7 +9,6 @@ if (!function_exists('debug')) {
 }
 
 class CORALInstaller {
-  session_start();
 
   public $db; // because CORALInstaller::query does unwanted things with result
   public $error;


### PR DESCRIPTION
Invoking session_start() inside class CORALInstaller triggers an syntax error with an unexpected T_STRING. I'm moving it back up to the beginning of the file where Usage's CORALInstaller.php has it. 

Does any one know a reason why we shouldn't do this?