### PR TITLE
Fix session_start() installation bug.

### DIFF
--- a/resources/install/CORALInstaller.php
+++ b/resources/install/CORALInstaller.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require_once('../directory.php');
 
 if (!function_exists('debug')) {
@@ -8,7 +9,6 @@ if (!function_exists('debug')) {
 }
 
 class CORALInstaller {
-  session_start();
 
   public $db; // because CORALInstaller::query does unwanted things with result
   public $error;


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected 'session_start' (T_STRING), expecting function (T_FUNCTION) in /…/coral/resources/install/CORALInstaller.php on line 11

This fix makes this file the same as the installer in the licensing module.