### PR TITLE
Resources: fix new resource link id

### DIFF
--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -170,7 +170,7 @@ $coralURL = $util->getCORALURL();
     </a>
 
 <?php if ($user->isAdmin() || $user->canEdit()){ ?>
-    <a href='ajax_forms.php?action=getNewResourceForm&height=503&width=775&resourceID=&modal=true' class='thickbox' id='newLicense'>
+    <a href='ajax_forms.php?action=getNewResourceForm&height=503&width=775&resourceID=&modal=true' class='thickbox' id='newResource'>
         <div class="main-menu-link">
             <img src="images/menu/icon-plus-square.png" />
             <span><?php echo _("New Resource");?></span>


### PR DESCRIPTION
It was 'newLicense' instead of 'newResource'.
It doesn't seem to be used anywhere:
- after searching 'newLicense' in the code.
- after checking in the browser the JS callbacks on the link.
So no regression is expected.

Clicking on it and creating a resource still works.