### PR TITLE
Issue 105: Resource list not showing up with MySQL 5.7

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1366,7 +1366,7 @@ class Resource extends DatabaseObject {
 		$alphArray = array();
 		$result = $this->db->query("SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1)) letter_count
 								FROM Resource R
-								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1)
+								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1), titleText
 								ORDER BY 1;");
 
 		while ($row = $result->fetch_assoc()) {

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1366,7 +1366,7 @@ class Resource extends DatabaseObject {
 		$alphArray = array();
 		$result = $this->db->query("SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1)) letter_count
 								FROM Resource R
-								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1), titleText
+								GROUP BY UPPER(SUBSTR(TRIM(LEADING 'The ' FROM titleText),1,1))
 								ORDER BY 1;");
 
 		while ($row = $result->fetch_assoc()) {


### PR DESCRIPTION
This patch fixes resource list for MySQL 5.7.

See http://stackoverflow.com/questions/34115174/i-am-getting-an-error-in-mysql-related-to-only-full-group-by-when-executing-a-qu for reference.

Fixes issue #105 
