### PR TITLE
Fix default timestamps to be compatible with MySQL 5.7 - issue #50

### DIFF
--- a/auth/install/create_tables_data.sql
+++ b/auth/install/create_tables_data.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `Session` (
   `sessionID` varchar(100) NOT NULL default '',
   `loginID` varchar(50) default NULL,
-  `timestamp` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `timestamp` timestamp NOT NULL default CURRENT_TIMESTAMP,
   PRIMARY KEY  (`sessionID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 

--- a/licensing/install/protected/install.sql
+++ b/licensing/install/protected/install.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS `Expression` (
   `expressionTypeID` int(10) unsigned NOT NULL,
   `documentText` text,
   `simplifiedText` text,
-  `lastUpdateDate` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `lastUpdateDate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   `productionUseInd` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`expressionID`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `ExpressionNote` (
   `expressionID` int(10) default NULL,
   `note` varchar(2000) default NULL,
   `displayOrderSeqNumber` int(10) default NULL,
-  `lastUpdateDate` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `lastUpdateDate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   PRIMARY KEY  (`expressionNoteID`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 

--- a/management/install/protected/install.sql
+++ b/management/install/protected/install.sql
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS `Expression` (
   `expressionTypeID` int(10) unsigned NOT NULL,
   `documentText` text,
   `simplifiedText` text,
-  `lastUpdateDate` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `lastUpdateDate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   `productionUseInd` tinyint(1) NOT NULL default '0',
   PRIMARY KEY  (`expressionID`),
   KEY `documentID` (`documentID`),
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS `ExpressionNote` (
   `expressionID` int(10) default NULL,
   `note` varchar(2000) default NULL,
   `displayOrderSeqNumber` int(10) default NULL,
-  `lastUpdateDate` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `lastUpdateDate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   PRIMARY KEY  (`expressionNoteID`),
   KEY `expressionID` (`expressionID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/resources/install/protected/install.sql
+++ b/resources/install/protected/install.sql
@@ -406,7 +406,7 @@ CREATE TABLE  `ResourceNote` (
   `resourceID` int(11) default NULL,
   `noteTypeID` int(11) default NULL,
   `tabName` varchar(45) default NULL,
-  `updateDate` timestamp NOT NULL default '0000-00-00 00:00:00',
+  `updateDate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   `updateLoginID` varchar(45) default NULL,
   `noteText` text,
   PRIMARY KEY  (`resourceNoteID`)


### PR DESCRIPTION
An install was successfully done (except for module Reports #110 ) on MySQL 5.7, PHP 7, Ubuntu 16.04.

And a resource was created.

Fixes #50
