### PR TITLE
Foundations of test suite with DB isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Composer: installed libs folder
+vendor/
+
+# Codeception temp and generated files
+tests/_output/
+tests/_support/_generated/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Composer: installed libs folder
 vendor/
 
+# Composer: installed binaries: PhantomJS and PHPUnit
+bin/
+
 # Codeception temp and generated files
 tests/_output/
 tests/_support/_generated/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Composer: installed libs folder
 vendor/
 
-# Composer: installed binaries: PhantomJS and PHPUnit
+# Composer: installed binaries: PhantomJS, Codeception
 bin/
 
 # Codeception temp and generated files

--- a/README
+++ b/README
@@ -2,6 +2,9 @@
 Installation
 These files are intended to be copied into the /coral/ directory on your web server.  The index should only display active links for the modules you have under the directory as long as the name matches the naming in Github (e.g. /coral/resources/)
 
+**************************
+Automated tests
+See the file TEST.md
 
 **************************
 License / Copyright notices

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,71 @@
+# Setup
+## Install composer
+### Create /bin folder
+`mkdir bin`
+### Download composer
+`wget -O bin/composer https://getcomposer.org/download/1.2.0/composer.phar && chmod +x bin/composer`
+## Enable PHP extensions
+Method + which are already there vary depending your on Linux distribution or if you on Windows.
+### bz2: used to extract PhantomJS
+### curl: so WebDriver can communicate with PhantomJS
+### mbstring: required by Codeception
+### dom: required by Codeception/PHPUnit (package php-xml on Ubuntu)
+
+## Install dependencies
+`bin/composer install`
+
+# Running the tests
+## 0. Important things to know
+As of today, the tests don't run in a separate database.
+It's just automating some checks that you would do manually on your local instance.
+Nothing more. This means that when a test fails, it might leave some test data which could make fail subsequent test runs.
+Therefore manual cleanup might be required.
+This is a big limitation, hopefully database separation for the tests will be implemented soon enough.
+## 1. Launch PhantomJS in a terminal
+`bin/phantomjs --webdriver=4444`
+## 2. Run the test suite (provide the url and credentials for your local Coral instance)
+`BASE_URL=http://localhost/coral/ CORAL_LOGIN=my_login CORAL_PASS="my passphrase" bin/codecept run -vv`
+
+
+# Guidelines writing new tests
+
+## The tests must clean their own data
+As mentioned earlier, there is currently no database isolation for tests.
+Therefore they need to clean any created data that might interfere with further test runs.
+Like when doing manual checking one have to clean it's data.
+The tests should be designed be ran as many times as we wish without causing trouble.
+
+## Be careful when checking that something is not here
+Such checks are prone to false negative (passing when they shouldn't).
+For example, checking that something deleted is no more listed somewhere.
+
+A simple check that some string or some CSS selector is not here might always
+succeed because of the page not having fully loaded yet. (Ajax)
+
+For these cases, the helper `$I->waitForPageToBeReady();` should do the trick
+without requiring a specific check like `waitForText` or `waitForElement`.
+That being said, you should always check that you test is correct by either
+- sabotaging the test or Coral to make appear the thing that should not be here and see if your test catches it.
+  This is the most reliable approach.
+- taking a screenshot before the `$I->dontSee('something');` to see if the page
+is fully loaded. (after your confident, remove the screenshot before committing)
+
+In either case, you should run the tests various times to double check that it
+consistently works (sabotage is always caught or screenshot always shows the page fully loaded) because these issues are sporadic.
+
+# Test architecture
+![stack-experimental-codeception](https://cloud.githubusercontent.com/assets/2678215/17975154/ee52bdfc-6ae8-11e6-97f7-f45ff43b6e7d.png)
+[source (ODG format)](https://github.com/Coral-erm/Coral/files/437395/stack-experimental-codeception.zip)
+
+## Codeception
+- Built on top of PHPUnit: syntactic sugar, helper functions and scaffolders(create test files and folders skeletons) to limit the amount of boilerplate code to write.
+- Can also run PHPUnit tests.
+- Provides facilities to shared code between tests and create custom functions to interact with the pages.
+
+http://codeception.com/docs/06-ModulesAndHelpers
+
+http://codeception.com/docs/06-ReusingTestCode
+
+- Supports BDD (Behavior Driven Development) style tests: written in a syntax close to natural language that if embraced will be readable by librarians.
+
+http://codeception.com/docs/07-BDD

--- a/TESTS.md
+++ b/TESTS.md
@@ -5,36 +5,47 @@
 ### Download composer
 `wget -O bin/composer https://getcomposer.org/download/1.2.0/composer.phar && chmod +x bin/composer`
 ## Enable PHP extensions
-Method + which are already there vary depending your on Linux distribution or if you on Windows.
-### bz2: used to extract PhantomJS
-### curl: so WebDriver can communicate with PhantomJS
-### mbstring: required by Codeception
-### dom: required by Codeception/PHPUnit (package php-xml on Ubuntu)
+Method + which are already there vary depending on your Linux distribution or if you're on Windows.
+
+- bz2: used to extract PhantomJS
+- curl: so WebDriver can communicate with PhantomJS
+- mbstring: required by Codeception
+- dom: required by Codeception/PHPUnit (package php-xml on Ubuntu)
 
 ## Install dependencies
 `bin/composer install`
 
+## Create the test databases
+```
+CREATE DATABASE coral_auth_test;
+CREATE DATABASE coral_resources_test;
+CREATE DATABASE coral_licensing_test;
+CREATE DATABASE coral_management_test;
+CREATE DATABASE coral_organizations_test;
+CREATE DATABASE coral_usage_test;
+CREATE DATABASE coral_reports_test;
+```
+
+Your DBMS should be configured to accept connections only from localhost.
+So having a static passphrase and user for the test DBs shouldn't be an issue.
+```
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_auth_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_resources_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_licensing_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_management_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_organizations_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_usage_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+GRANT CREATE, DROP, ALTER, SELECT, INSERT, UPDATE, DELETE, LOCK TABLES ON coral_reports_test.* TO 'coral_test'@'localhost' IDENTIFIED BY 'coral_test';
+```
+
 # Running the tests
-## 0. Important things to know
-As of today, the tests don't run in a separate database.
-It's just automating some checks that you would do manually on your local instance.
-Nothing more. This means that when a test fails, it might leave some test data which could make fail subsequent test runs.
-Therefore manual cleanup might be required.
-This is a big limitation, hopefully database separation for the tests will be implemented soon enough.
 ## 1. Launch PhantomJS in a terminal
-`bin/phantomjs --webdriver=4444`
-## 2. Run the test suite (provide the url and credentials for your local Coral instance)
-`BASE_URL=http://localhost/coral/ CORAL_LOGIN=my_login CORAL_PASS="my passphrase" bin/codecept run -vv`
+`bin/phantomjs --webdriver=4444 --webdriver-loglevel=DEBUG`
+## 2. Run the test suite (provide the url of your local Coral instance)
+`BASE_URL=http://localhost/coral/ bin/codecept run -vv`
 
 
 # Guidelines writing new tests
-
-## The tests must clean their own data
-As mentioned earlier, there is currently no database isolation for tests.
-Therefore they need to clean any created data that might interfere with further test runs.
-Like when doing manual checking one have to clean it's data.
-The tests should be designed be ran as many times as we wish without causing trouble.
-
 ## Be careful when checking that something is not here
 Such checks are prone to false negative (passing when they shouldn't).
 For example, checking that something deleted is no more listed somewhere.

--- a/admin/.htaccess
+++ b/admin/.htaccess
@@ -1,0 +1,2 @@
+order deny,allow
+deny from all

--- a/admin/configuration.ini
+++ b/admin/configuration.ini
@@ -1,0 +1,3 @@
+
+[settings]
+environment = "prod"

--- a/auth/admin/classes/common/Configuration.php
+++ b/auth/admin/classes/common/Configuration.php
@@ -20,13 +20,48 @@
 class Configuration extends DynamicObject {
 
 	public function init(NamedArguments $arguments) {
-		$arguments->setDefaultValueForArgumentName('filename', BASE_DIR . '/admin/configuration.ini');
-		$config = parse_ini_file($arguments->filename, true);
+		$global_config = parse_ini_file(BASE_DIR . "../admin/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_merge_recursive($module_config, $global_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
 			$this->$section = Utility::objectFromArray($entries);
 		}
 	}
 
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_auth_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabase"])) {
+			$config["database"]["usageDatabase"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
 }
 
 ?>

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,21 @@
+actor: Tester
+paths:
+    tests: tests
+    log: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
+settings:
+    bootstrap: _bootstrap.php
+    colors: true
+    memory_limit: 1024M
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed
+modules:
+    config:
+        Db:
+            dsn: ''
+            user: ''
+            password: ''
+            dump: tests/_data/dump.sql

--- a/codeception.yml
+++ b/codeception.yml
@@ -19,3 +19,5 @@ modules:
             user: ''
             password: ''
             dump: tests/_data/dump.sql
+params:
+    - env # load params from environment vars

--- a/codeception.yml
+++ b/codeception.yml
@@ -13,11 +13,6 @@ extensions:
     enabled:
         - Codeception\Extension\RunFailed
 modules:
-    config:
-        Db:
-            dsn: ''
-            user: ''
-            password: ''
-            dump: tests/_data/dump.sql
+    enabled: []
 params:
     - env # load params from environment vars

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "codeception/codeception": "^2.2"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,17 @@
 {
-    "require": {
-        "codeception/codeception": "^2.2"
+    "require-dev": {
+        "codeception/codeception": "~2.2",
+        "jakoch/phantomjs-installer": "^2.1"
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "PhantomInstaller\\Installer::installPhantomJS"
+        ],
+        "post-update-cmd": [
+            "PhantomInstaller\\Installer::installPhantomJS"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,15 @@
 {
     "require-dev": {
         "codeception/codeception": "~2.2",
-        "jakoch/phantomjs-installer": "^2.1"
+        "jakoch/phantomjs-installer": "^2.1",
+        "pear-pear.php.net/config_lite": "*"
     },
+    "repositories": [
+        {
+            "type": "pear",
+            "url": "https://pear.php.net"
+        }
+    ],
     "config": {
         "bin-dir": "bin"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,10 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fb5785c0a0e075cde41e6c79ac15d771",
-    "content-hash": "c4884e34fd65287a5a178a1f79d98a2e",
-    "packages": [
+    "hash": "87924624e6a37ff974dd5bbb759807e8",
+    "content-hash": "8975956210f7970c1137232543f3b051",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "behat/gherkin",
             "version": "v4.4.1",
@@ -67,16 +68,16 @@
         },
         {
             "name": "codeception/codeception",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "34c268ae5872105c0c218296487650ab08e3991b"
+                "reference": "ea617b8b55e6e33cdd47edeafde5d3f6466049e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/34c268ae5872105c0c218296487650ab08e3991b",
-                "reference": "34c268ae5872105c0c218296487650ab08e3991b",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/ea617b8b55e6e33cdd47edeafde5d3f6466049e2",
+                "reference": "ea617b8b55e6e33cdd47edeafde5d3f6466049e2",
                 "shasum": ""
             },
             "require": {
@@ -154,7 +155,7 @@
                 "functional testing",
                 "unit testing"
             ],
-            "time": "2016-07-24 19:31:22"
+            "time": "2016-08-14 12:28:58"
         },
         {
             "name": "doctrine/instantiator",
@@ -212,16 +213,16 @@
         },
         {
             "name": "facebook/webdriver",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "0b889d7de7461439f8a3bbcca46e0f696cb27986"
+                "reference": "b7186fb1bcfda956d237f59face250d06ef47253"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/0b889d7de7461439f8a3bbcca46e0f696cb27986",
-                "reference": "0b889d7de7461439f8a3bbcca46e0f696cb27986",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/b7186fb1bcfda956d237f59face250d06ef47253",
+                "reference": "b7186fb1bcfda956d237f59face250d06ef47253",
                 "shasum": ""
             },
             "require": {
@@ -229,7 +230,9 @@
                 "php": ">=5.3.19"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.6.*"
+                "friendsofphp/php-cs-fixer": "^1.11",
+                "phpunit/phpunit": "4.6.* || ~5.0",
+                "squizlabs/php_codesniffer": "^2.6"
             },
             "suggest": {
                 "phpdocumentor/phpdocumentor": "2.*"
@@ -252,7 +255,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2016-06-04 00:02:34"
+            "time": "2016-08-10 00:44:08"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -424,6 +427,48 @@
                 "uri"
             ],
             "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "jakoch/phantomjs-installer",
+            "version": "2.1.1-p06",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jakoch/phantomjs-installer.git",
+                "reference": "26f870052263c00d09103928ad39c935108f51d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jakoch/phantomjs-installer/zipball/26f870052263c00d09103928ad39c935108f51d4",
+                "reference": "26f870052263c00d09103928ad39c935108f51d4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bz2": "*",
+                "ext-openssl": "*"
+            },
+            "type": "custom-installer",
+            "autoload": {
+                "psr-0": {
+                    "PhantomInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jens-André Koch",
+                    "email": "jakoch@web.de"
+                }
+            ],
+            "description": "A Composer package which installs the PhantomJS binary (Linux, Windows, Mac) into `/bin` of your project.",
+            "keywords": [
+                "binaries",
+                "headless",
+                "phantomjs"
+            ],
+            "time": "2016-08-09 10:14:29"
         },
         {
             "name": "myclabs/deep-copy",
@@ -999,16 +1044,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.3",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
-                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
+                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
                 "shasum": ""
             },
             "require": {
@@ -1054,20 +1099,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-06-12 07:37:26"
+            "time": "2016-08-26 05:51:59"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
-                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "shasum": ""
             },
             "require": {
@@ -1095,6 +1140,7 @@
                 }
             ],
             "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
             "keywords": [
                 "http",
                 "http-message",
@@ -1103,7 +1149,7 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1268,23 +1314,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -1314,7 +1360,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-08-18 05:49:44"
         },
         {
             "name": "sebastian/exporter",
@@ -1620,16 +1666,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "dcf41ed026b0499254385b5c88f03247b2ba010b"
+                "reference": "d2a07cc11c5fa94820240b1e67592ffb18e347b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/dcf41ed026b0499254385b5c88f03247b2ba010b",
-                "reference": "dcf41ed026b0499254385b5c88f03247b2ba010b",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/d2a07cc11c5fa94820240b1e67592ffb18e347b9",
+                "reference": "d2a07cc11c5fa94820240b1e67592ffb18e347b9",
                 "shasum": ""
             },
             "require": {
@@ -1673,20 +1719,20 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-26 08:04:17"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a"
+                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/747154aa69b0f83cd02fc9aa554836dee417631a",
-                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f9e638e8149e9e41b570ff092f8007c477ef0ce5",
+                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5",
                 "shasum": ""
             },
             "require": {
@@ -1733,11 +1779,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 07:02:31"
+            "time": "2016-07-26 08:04:17"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -1790,16 +1836,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0"
+                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
-                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
+                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
                 "shasum": ""
             },
             "require": {
@@ -1842,20 +1888,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-26 08:04:17"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
                 "shasum": ""
             },
             "require": {
@@ -1902,11 +1948,11 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-19 10:45:57"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2014,16 +2060,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
-                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1819adf2066880c7967df7180f4f662b6f0567ac",
+                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac",
                 "shasum": ""
             },
             "require": {
@@ -2059,32 +2105,33 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-07-17 14:02:08"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
-                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3|^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -2108,55 +2155,9 @@
                 "check",
                 "validate"
             ],
-            "time": "2015-08-24 13:29:44"
-        },
-        {
-            "name": "zendframework/zend-dom",
-            "version": "2.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-dom.git",
-                "reference": "a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-dom/zipball/a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e",
-                "reference": "a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Dom\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides tools for working with DOM documents and structures",
-            "homepage": "https://github.com/zendframework/zend-dom",
-            "keywords": [
-                "dom",
-                "zf2"
-            ],
-            "time": "2015-10-14 03:37:48"
+            "time": "2016-08-09 15:02:57"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2167 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "fb5785c0a0e075cde41e6c79ac15d771",
+    "content-hash": "c4884e34fd65287a5a178a1f79d98a2e",
+    "packages": [
+        {
+            "name": "behat/gherkin",
+            "version": "v4.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Gherkin.git",
+                "reference": "1576b485c0f92ef6d27da9c4bbfc57ee30cf6911"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/1576b485c0f92ef6d27da9c4bbfc57ee30cf6911",
+                "reference": "1576b485c0f92ef6d27da9c4bbfc57ee30cf6911",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to parse features, represented in YAML files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Gherkin": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Gherkin DSL parser for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Cucumber",
+                "DSL",
+                "gherkin",
+                "parser"
+            ],
+            "time": "2015-12-30 14:47:00"
+        },
+        {
+            "name": "codeception/codeception",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/Codeception.git",
+                "reference": "34c268ae5872105c0c218296487650ab08e3991b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/34c268ae5872105c0c218296487650ab08e3991b",
+                "reference": "34c268ae5872105c0c218296487650ab08e3991b",
+                "shasum": ""
+            },
+            "require": {
+                "behat/gherkin": "~4.4.0",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "facebook/webdriver": ">=1.0.1 <2.0",
+                "guzzlehttp/guzzle": ">=4.1.4 <7.0",
+                "guzzlehttp/psr7": "~1.0",
+                "php": ">=5.4.0 <8.0",
+                "phpunit/php-code-coverage": ">=2.1.3",
+                "phpunit/phpunit": ">4.8.20 <5.5",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "^1.4",
+                "symfony/browser-kit": ">=2.7 <4.0",
+                "symfony/console": ">=2.7 <4.0",
+                "symfony/css-selector": ">=2.7 <4.0",
+                "symfony/dom-crawler": ">=2.7 <4.0",
+                "symfony/event-dispatcher": ">=2.7 <4.0",
+                "symfony/finder": ">=2.7 <4.0",
+                "symfony/yaml": ">=2.7 <4.0"
+            },
+            "require-dev": {
+                "codeception/specify": "~0.3",
+                "facebook/php-sdk-v4": "~5.0",
+                "flow/jsonpath": "~0.2",
+                "league/factory-muffin": "^3.0",
+                "league/factory-muffin-faker": "^1.0",
+                "mongodb/mongodb": "^1.0",
+                "monolog/monolog": "~1.8",
+                "pda/pheanstalk": "~3.0",
+                "php-amqplib/php-amqplib": "~2.4",
+                "predis/predis": "^1.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "codeception/specify": "BDD-style code blocks",
+                "codeception/verify": "BDD-style assertions",
+                "flow/jsonpath": "For using JSONPath in REST module",
+                "league/factory-muffin": "For DataFactory module",
+                "league/factory-muffin-faker": "For Faker support in DataFactory module",
+                "phpseclib/phpseclib": "for SFTP option in FTP Module",
+                "symfony/phpunit-bridge": "For phpunit-bridge support"
+            },
+            "bin": [
+                "codecept"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Codeception\\": "src\\Codeception",
+                    "Codeception\\Extension\\": "ext"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Bodnarchuk",
+                    "email": "davert@mail.ua",
+                    "homepage": "http://codegyre.com"
+                }
+            ],
+            "description": "BDD-style testing framework",
+            "homepage": "http://codeception.com/",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "acceptance testing",
+                "functional testing",
+                "unit testing"
+            ],
+            "time": "2016-07-24 19:31:22"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "facebook/webdriver",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebook/php-webdriver.git",
+                "reference": "0b889d7de7461439f8a3bbcca46e0f696cb27986"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/0b889d7de7461439f8a3bbcca46e0f696cb27986",
+                "reference": "0b889d7de7461439f8a3bbcca46e0f696cb27986",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.19"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.6.*"
+            },
+            "suggest": {
+                "phpdocumentor/phpdocumentor": "2.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "A PHP client for WebDriver",
+            "homepage": "https://github.com/facebook/php-webdriver",
+            "keywords": [
+                "facebook",
+                "php",
+                "selenium",
+                "webdriver"
+            ],
+            "time": "2016-06-04 00:02:34"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-07-15 17:22:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
+                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2015-11-20 12:04:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-06-10 09:48:41"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-06-07 08:13:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.4.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:39:29"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3132365e1430c091f208e120b8845d39c25f20e6",
+                "reference": "3132365e1430c091f208e120b8845d39c25f20e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "^4.0.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:48:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b13d0d9426ced06958bd32104653526a6c998a52",
+                "reference": "b13d0d9426ced06958bd32104653526a6c998a52",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2016-06-12 07:37:26"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-05-17 03:18:57"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "symfony/browser-kit",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/browser-kit.git",
+                "reference": "dcf41ed026b0499254385b5c88f03247b2ba010b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/dcf41ed026b0499254385b5c88f03247b2ba010b",
+                "reference": "dcf41ed026b0499254385b5c88f03247b2ba010b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/dom-crawler": "~2.8|~3.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\BrowserKit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony BrowserKit Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/747154aa69b0f83cd02fc9aa554836dee417631a",
+                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 07:02:31"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "2851e1932d77ce727776154d659b232d061e816a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/2851e1932d77ce727776154d659b232d061e816a",
+                "reference": "2851e1932d77ce727776154d659b232d061e816a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
+                "reference": "99ec4a23330fcd0c8667095f3ef7aa204ffd9dc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "reference": "2884c26ce4c1d61aebf423a8b912950fe7c764de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:41:56"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "reference": "30eed06dd6bc88410a4ff7f77b6d22f3ce13dbde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2015-08-24 13:29:44"
+        },
+        {
+            "name": "zendframework/zend-dom",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-dom.git",
+                "reference": "a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-dom/zipball/a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e",
+                "reference": "a9e145b2b52fe6de5a7a6b0ddb5c773c2c72d59e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Dom\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides tools for working with DOM documents and structures",
+            "homepage": "https://github.com/zendframework/zend-dom",
+            "keywords": [
+                "dom",
+                "zf2"
+            ],
+            "time": "2015-10-14 03:37:48"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "87924624e6a37ff974dd5bbb759807e8",
-    "content-hash": "8975956210f7970c1137232543f3b051",
+    "hash": "32223075c0f68b5a3566fc3dcb5bdb5f",
+    "content-hash": "2f8454b5577b297d803419488881f24e",
     "packages": [],
     "packages-dev": [
         {
             "name": "behat/gherkin",
-            "version": "v4.4.1",
+            "version": "v4.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "1576b485c0f92ef6d27da9c4bbfc57ee30cf6911"
+                "reference": "d26757dc970e67b50ed0ee47b95273daeb84fea6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/1576b485c0f92ef6d27da9c4bbfc57ee30cf6911",
-                "reference": "1576b485c0f92ef6d27da9c4bbfc57ee30cf6911",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/d26757dc970e67b50ed0ee47b95273daeb84fea6",
+                "reference": "d26757dc970e67b50ed0ee47b95273daeb84fea6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.1"
+                "phpunit/phpunit": "~4.5|~5",
+                "symfony/phpunit-bridge": "~2.7|~3",
+                "symfony/yaml": "~2.3|~3"
             },
             "suggest": {
                 "symfony/yaml": "If you want to parse features, represented in YAML files"
@@ -64,7 +65,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2015-12-30 14:47:00"
+            "time": "2016-09-03 07:28:57"
         },
         {
             "name": "codeception/codeception",
@@ -472,16 +473,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.5.1",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+                "reference": "94e5ca3e90aa5b34663780393e10914f7438f991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/94e5ca3e90aa5b34663780393e10914f7438f991",
+                "reference": "94e5ca3e90aa5b34663780393e10914f7438f991",
                 "shasum": ""
             },
             "require": {
@@ -510,7 +511,36 @@
                 "object",
                 "object graph"
             ],
-            "time": "2015-11-20 12:04:31"
+            "time": "2016-09-07 15:34:10"
+        },
+        {
+            "name": "pear-pear.php.net/Config_Lite",
+            "version": "0.2.5",
+            "dist": {
+                "type": "file",
+                "url": "https://pear.php.net/get/Config_Lite-0.2.5.tgz",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "php": ">=5.2.0.0"
+            },
+            "replace": {
+                "pear-pear/config_lite": "== 0.2.5.0"
+            },
+            "type": "pear-library",
+            "autoload": {
+                "classmap": [
+                    ""
+                ]
+            },
+            "include-path": [
+                "/"
+            ],
+            "license": [
+                "lgpl"
+            ],
+            "description": "This package defines a class for config/settings text files in ini style.\n\t\tCurrently classes available are:\n\t\t* Config_Lite: a class with arrayaccess to handle ini style files\n\t\t* Config_Lite_Exception: Interface implemented by Exceptions"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1044,16 +1074,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.2.6",
+            "version": "3.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49"
+                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
-                "reference": "46b249b43fd2ed8e127aa0fdb3cbcf56e9bc0e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
+                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
                 "shasum": ""
             },
             "require": {
@@ -1099,7 +1129,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-08-26 05:51:59"
+            "time": "2016-09-06 16:07:45"
         },
         {
             "name": "psr/http-message",
@@ -1666,7 +1696,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
@@ -1723,16 +1753,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5"
+                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f9e638e8149e9e41b570ff092f8007c477ef0ce5",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8ea494c34f0f772c3954b5fbe00bffc5a435e563",
+                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563",
                 "shasum": ""
             },
             "require": {
@@ -1779,11 +1809,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 08:04:17"
+            "time": "2016-08-19 06:48:39"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -1836,16 +1866,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9"
+                "reference": "bb7395e8b1db3654de82b9f35d019958276de4d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
-                "reference": "c7b9b8db3a6f2bac76dcd9a9db5446f2591897f9",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/bb7395e8b1db3654de82b9f35d019958276de4d7",
+                "reference": "bb7395e8b1db3654de82b9f35d019958276de4d7",
                 "shasum": ""
             },
             "require": {
@@ -1888,11 +1918,11 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 08:04:17"
+            "time": "2016-08-05 08:37:39"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -1952,16 +1982,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7"
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8201978de88a9fa0923e18601bb17f1df9c721e7",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e568ef1784f447a0e54dcb6f6de30b9747b0f577",
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577",
                 "shasum": ""
             },
             "require": {
@@ -1997,7 +2027,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-08-26 12:04:02"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2060,16 +2090,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac"
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1819adf2066880c7967df7180f4f662b6f0567ac",
-                "reference": "1819adf2066880c7967df7180f4f662b6f0567ac",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
                 "shasum": ""
             },
             "require": {
@@ -2105,7 +2135,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17 14:02:08"
+            "time": "2016-09-02 02:12:52"
         },
         {
             "name": "webmozart/assert",

--- a/licensing/admin/classes/common/Configuration.php
+++ b/licensing/admin/classes/common/Configuration.php
@@ -20,13 +20,48 @@
 class Configuration extends DynamicObject {
 
 	public function init(NamedArguments $arguments) {
-		$arguments->setDefaultValueForArgumentName('filename', BASE_DIR . '/admin/configuration.ini');
-		$config = parse_ini_file($arguments->filename, true);
+		$global_config = parse_ini_file(BASE_DIR . "../admin/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_merge_recursive($module_config, $global_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
 			$this->$section = Utility::objectFromArray($entries);
 		}
 	}
 
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_licensing_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabase"])) {
+			$config["database"]["usageDatabase"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
 }
 
 ?>

--- a/management/admin/classes/common/Configuration.php
+++ b/management/admin/classes/common/Configuration.php
@@ -20,13 +20,48 @@
 class Configuration extends DynamicObject {
 
 	public function init(NamedArguments $arguments) {
-		$arguments->setDefaultValueForArgumentName('filename', BASE_DIR . '/admin/configuration.ini');
-		$config = parse_ini_file($arguments->filename, true);
+		$global_config = parse_ini_file(BASE_DIR . "../admin/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_merge_recursive($module_config, $global_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
 			$this->$section = Utility::objectFromArray($entries);
 		}
 	}
 
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_management_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabase"])) {
+			$config["database"]["usageDatabase"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
 }
 
 ?>

--- a/organizations/admin/classes/common/Configuration.php
+++ b/organizations/admin/classes/common/Configuration.php
@@ -20,13 +20,48 @@
 class Configuration extends DynamicObject {
 
 	public function init(NamedArguments $arguments) {
-		$arguments->setDefaultValueForArgumentName('filename', BASE_DIR . '/admin/configuration.ini');
-		$config = parse_ini_file($arguments->filename, true);
+		$global_config = parse_ini_file(BASE_DIR . "../admin/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_merge_recursive($module_config, $global_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
 			$this->$section = Utility::objectFromArray($entries);
 		}
 	}
 
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_organizations_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabase"])) {
+			$config["database"]["usageDatabase"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
 }
 
 ?>

--- a/resources/admin/classes/common/Configuration.php
+++ b/resources/admin/classes/common/Configuration.php
@@ -20,13 +20,48 @@
 class Configuration extends DynamicObject {
 
 	public function init(NamedArguments $arguments) {
-		$arguments->setDefaultValueForArgumentName('filename', BASE_DIR . '/admin/configuration.ini');
-		$config = parse_ini_file($arguments->filename, true);
+		$global_config = parse_ini_file(BASE_DIR . "../admin/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_merge_recursive($module_config, $global_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
 			$this->$section = Utility::objectFromArray($entries);
 		}
 	}
 
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_resources_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabase"])) {
+			$config["database"]["usageDatabase"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
 }
 
 ?>

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,0 +1,2 @@
+order deny,allow
+deny from all

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// This is global bootstrap for autoloading

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,2 +1,5 @@
 <?php
 // This is global bootstrap for autoloading
+
+// Load composer's autoloader to use installed packages in tests
+require __DIR__ . "/../vendor/autoload.php";

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -1,1 +1,0 @@
-/* Replace this file with actual dump of your database */

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -1,0 +1,1 @@
+/* Replace this file with actual dump of your database */

--- a/tests/_data/test_database.sql
+++ b/tests/_data/test_database.sql
@@ -1,0 +1,4013 @@
+/*
+READ THIS! ##############################################
+If you need to regenerate this because
+- The Coral setup changed.
+Or
+- You need data that will be used in *most* of the tests
+  Keep the test DB a small as possible, as it will be loaded before *every* test
+
+Here are the instructions:
+1. Do a clean Coral install
+   With an admin user "coral_test" with a passphrase "coral_test"
+2. Login
+3. Create a resource type
+4. Create a resource
+5. Dump the DB with
+   mysqldump -u MY_USER -p --databases coral_auth_prod coral_licensing_prod coral_management_prod coral_organizations_prod coral_reports_prod coral_resources_prod coral_usage_prod  > dump.sql
+   You should need to use your root DB user as your coral DB user won't be authorized to LOCK TABLE
+6. Remove the CREATE DATABASE from the dump
+7. Update the CORALSessionID in tests/_support/Helper/Acceptance.php with the
+   value from the dump in the Session table. Or set it back to the one in
+   Acceptance.php
+8. Replace the DB name with the test ones. See TEST.md
+9. Include this comment! (and make sure it's up to date)
+*/
+
+
+
+-- MySQL dump 10.16  Distrib 10.1.17-MariaDB, for Linux (x86_64)
+--
+-- Host: localhost    Database: coral_auth_test
+-- ------------------------------------------------------
+-- Server version	10.1.17-MariaDB
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Current Database: `coral_auth_test`
+--
+
+USE `coral_auth_test`;
+
+--
+-- Table structure for table `Session`
+--
+
+DROP TABLE IF EXISTS `Session`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Session` (
+  `sessionID` varchar(100) NOT NULL DEFAULT '',
+  `loginID` varchar(50) DEFAULT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`sessionID`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Session`
+--
+
+LOCK TABLES `Session` WRITE;
+/*!40000 ALTER TABLE `Session` DISABLE KEYS */;
+INSERT INTO `Session` VALUES ('bNWUrFmjzDtoyxXSyxlwLMROC5W5LwvnAH7sMkRBnBqcyDum1VZCiqRlmngyaRbbYZJl9anncTFQX03PMSSu9jWlN2ZoJ1FiQPJQ','coral_test','2016-09-09 15:53:20');
+/*!40000 ALTER TABLE `Session` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL,
+  `password` varchar(250) DEFAULT NULL,
+  `passwordPrefix` varchar(50) DEFAULT NULL,
+  `adminInd` varchar(1) DEFAULT 'N',
+  PRIMARY KEY (`loginID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test','302a5ecfa31bf5d84bd3cb698b4582eb3f037c11c4d98c2bc2e230a7dbf0acb5577564aecf53608547477466a418e74802643393852e9d7c67fcc9598b7c0d9c','t3tC9fC8GZyrDpzHuGyaxQ0RWvEG72vrvftvAvuGLixPN','Y');
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_licensing_test`
+--
+
+USE `coral_licensing_test`;
+
+--
+-- Table structure for table `Attachment`
+--
+
+DROP TABLE IF EXISTS `Attachment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Attachment` (
+  `attachmentID` int(10) NOT NULL AUTO_INCREMENT,
+  `licenseID` int(10) DEFAULT NULL,
+  `sentDate` date DEFAULT NULL,
+  `attachmentText` text,
+  PRIMARY KEY (`attachmentID`) USING BTREE,
+  KEY `licenseID` (`licenseID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Attachment`
+--
+
+LOCK TABLES `Attachment` WRITE;
+/*!40000 ALTER TABLE `Attachment` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Attachment` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AttachmentFile`
+--
+
+DROP TABLE IF EXISTS `AttachmentFile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AttachmentFile` (
+  `attachmentFileID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `attachmentID` int(10) unsigned NOT NULL,
+  `attachmentURL` varchar(200) NOT NULL,
+  PRIMARY KEY (`attachmentFileID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AttachmentFile`
+--
+
+LOCK TABLES `AttachmentFile` WRITE;
+/*!40000 ALTER TABLE `AttachmentFile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `AttachmentFile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `CalendarSettings`
+--
+
+DROP TABLE IF EXISTS `CalendarSettings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `CalendarSettings` (
+  `calendarSettingsID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  `value` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`calendarSettingsID`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `CalendarSettings`
+--
+
+LOCK TABLES `CalendarSettings` WRITE;
+/*!40000 ALTER TABLE `CalendarSettings` DISABLE KEYS */;
+INSERT INTO `CalendarSettings` VALUES (1,'Days Before Subscription End','730'),(2,'Days After Subscription End','90'),(3,'Resource Type(s)','1'),(4,'Authorized Site(s)','1');
+/*!40000 ALTER TABLE `CalendarSettings` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Consortium`
+--
+
+DROP TABLE IF EXISTS `Consortium`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Consortium` (
+  `consortiumID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`consortiumID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Consortium`
+--
+
+LOCK TABLES `Consortium` WRITE;
+/*!40000 ALTER TABLE `Consortium` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Consortium` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Document`
+--
+
+DROP TABLE IF EXISTS `Document`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Document` (
+  `documentID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  `documentTypeID` int(10) unsigned NOT NULL,
+  `licenseID` int(10) unsigned NOT NULL,
+  `effectiveDate` date DEFAULT NULL,
+  `expirationDate` date DEFAULT NULL,
+  `documentURL` varchar(200) DEFAULT NULL,
+  `parentDocumentID` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`documentID`),
+  KEY `licenseID` (`licenseID`),
+  KEY `documentTypeID` (`documentTypeID`),
+  KEY `parentDocumentID` (`parentDocumentID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Document`
+--
+
+LOCK TABLES `Document` WRITE;
+/*!40000 ALTER TABLE `Document` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Document` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DocumentType`
+--
+
+DROP TABLE IF EXISTS `DocumentType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DocumentType` (
+  `documentTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`documentTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DocumentType`
+--
+
+LOCK TABLES `DocumentType` WRITE;
+/*!40000 ALTER TABLE `DocumentType` DISABLE KEYS */;
+INSERT INTO `DocumentType` VALUES (1,'SERU'),(2,'Internal Acknowledgment'),(3,'Agreement'),(4,'Countersigned Agreement'),(5,'Amendment'),(6,'Consortium Authorization Statement'),(7,'Order Form');
+/*!40000 ALTER TABLE `DocumentType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Expression`
+--
+
+DROP TABLE IF EXISTS `Expression`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Expression` (
+  `expressionID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `expressionTypeID` int(10) unsigned NOT NULL,
+  `documentText` text,
+  `simplifiedText` text,
+  `lastUpdateDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `productionUseInd` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`expressionID`),
+  KEY `documentID` (`documentID`),
+  KEY `expressionTypeID` (`expressionTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Expression`
+--
+
+LOCK TABLES `Expression` WRITE;
+/*!40000 ALTER TABLE `Expression` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Expression` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionNote`
+--
+
+DROP TABLE IF EXISTS `ExpressionNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionNote` (
+  `expressionNoteID` int(10) NOT NULL AUTO_INCREMENT,
+  `expressionID` int(10) DEFAULT NULL,
+  `note` varchar(2000) DEFAULT NULL,
+  `displayOrderSeqNumber` int(10) DEFAULT NULL,
+  `lastUpdateDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`expressionNoteID`),
+  KEY `expressionID` (`expressionID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionNote`
+--
+
+LOCK TABLES `ExpressionNote` WRITE;
+/*!40000 ALTER TABLE `ExpressionNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExpressionNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionQualifierProfile`
+--
+
+DROP TABLE IF EXISTS `ExpressionQualifierProfile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionQualifierProfile` (
+  `expressionID` int(10) unsigned NOT NULL,
+  `qualifierID` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`expressionID`,`qualifierID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionQualifierProfile`
+--
+
+LOCK TABLES `ExpressionQualifierProfile` WRITE;
+/*!40000 ALTER TABLE `ExpressionQualifierProfile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExpressionQualifierProfile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionType`
+--
+
+DROP TABLE IF EXISTS `ExpressionType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionType` (
+  `expressionTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  `noteType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`expressionTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionType`
+--
+
+LOCK TABLES `ExpressionType` WRITE;
+/*!40000 ALTER TABLE `ExpressionType` DISABLE KEYS */;
+INSERT INTO `ExpressionType` VALUES (1,'Authorized Users','Internal'),(2,'Interlibrary Loan','Display'),(3,'Coursepacks','Display'),(4,'eReserves','Display'),(5,'Post Cancellation Access','Internal'),(6,'General Notes','Internal'),(7,'Jurisdiction (Choice of Forum)','Internal'),(8,'Third Party Archiving','Internal'),(9,'Confidentiality Clause','Internal'),(10,'Multi-year Term','Internal');
+/*!40000 ALTER TABLE `ExpressionType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `License`
+--
+
+DROP TABLE IF EXISTS `License`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `License` (
+  `licenseID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `consortiumID` int(10) unsigned DEFAULT NULL,
+  `organizationID` int(10) unsigned DEFAULT NULL,
+  `shortName` tinytext NOT NULL,
+  `statusID` int(10) unsigned DEFAULT NULL,
+  `statusDate` datetime DEFAULT NULL,
+  `createDate` datetime DEFAULT NULL,
+  PRIMARY KEY (`licenseID`),
+  KEY `organizationID` (`organizationID`),
+  KEY `consortiumID` (`consortiumID`),
+  KEY `statusID` (`statusID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `License`
+--
+
+LOCK TABLES `License` WRITE;
+/*!40000 ALTER TABLE `License` DISABLE KEYS */;
+/*!40000 ALTER TABLE `License` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Organization`
+--
+
+DROP TABLE IF EXISTS `Organization`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Organization` (
+  `organizationID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`organizationID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=289 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Organization`
+--
+
+LOCK TABLES `Organization` WRITE;
+/*!40000 ALTER TABLE `Organization` DISABLE KEYS */;
+INSERT INTO `Organization` VALUES (1,'Accessible Archives Inc'),(2,'ACCU Weather Sales and Services, Inc'),(3,'Adam Matthew Digital Ltd'),(4,'Agricultural History Society'),(5,'Agricultural Institute of Canada'),(6,'AICPA'),(7,'Akademiai Kiado'),(8,'Albert C. Muller'),(9,'Alexander Street Press, LLC'),(10,'Allen Press'),(11,'Alliance for Children and Families'),(12,'American Academy of Religion'),(13,'American Association for Cancer Research (AACR)'),(14,'American Association for the Advancement of Science (AAAS)'),(15,'American Association of Immunologists, Inc.'),(16,'American Concrete Institute (ACI)'),(17,'American Council of Learned Societies (ACLS)'),(18,'American Counseling Association'),(19,'American Economic Association (AEA)'),(20,'American Fisheries Society'),(21,'American Geophysical Union'),(22,'American Insitute of Physics (AIP)'),(23,'American Institute of Aeronautics and Astronautics (AIAA)'),(24,'American Library Association (ALA)'),(25,'American Mathematical Society (AMS)'),(26,'American Medical Association (AMA)'),(27,'American Meteorological Society (AMS)'),(28,'American Physical Society (APS)'),(29,'American Physiological Society'),(30,'American Phytopathological Society'),(31,'American Psychiatric Publishing'),(32,'American Psychological Association (APA)'),(33,'American Society for Cell Biology'),(34,'American Society for Clinical Investigation'),(35,'American Society for Horticultural Science'),(36,'American Society for Nutrition'),(37,'American Society for Testing and Materials (ASTM)'),(38,'American Society of Agronomy'),(39,'American Society of Civil Engineers (ASCE)'),(40,'American Society of Limnology and Oceanography (ASLO)'),(41,'American Society of Plant Biologists'),(42,'American Society of Tropical Medicine and Hygiene'),(43,'American Statistical Association'),(44,'Ammons Scientific Limited'),(45,'Annual Reviews'),(46,'Antiquity Publications Limited'),(47,'Applied Probability Trust'),(48,'Army Times Publishing Company'),(49,'ARTstor Inc'),(50,'Asempa Limited'),(51,'Association of Research Libraries (ARL)'),(52,'Atypon Systems Inc'),(53,'Augustine Institute'),(54,'Barkhuis Publishing'),(55,'Begell House, Inc'),(56,'Beilstein'),(57,'Belser Wissenschaftlicher Dienst Ltd'),(58,'Berg Publishers'),(59,'Berghahn Books'),(60,'Berkeley Electronic Press'),(61,'BIGresearch LLC'),(62,'BioMed Central'),(63,'BioOne'),(64,'Blackwell Publishing'),(65,'BMJ Publishing Group Limited'),(66,'Boopsie, INC.'),(67,'Botanical Society of America'),(68,'Boyd Printing'),(69,'Brepols Publishers'),(70,'Brill'),(71,'Bulletin of the Atomic Scientists'),(72,'Bureau of National Affairs, Inc'),(73,'Business Monitor International'),(74,'CABI Publishing'),(75,'Cambridge Crystallographic Data Centre'),(76,'Cambridge Scientific Abstracts'),(77,'Cambridge University Press'),(78,'Canadian Association of African Studies'),(79,'Canadian Mathematical Society'),(80,'Carbon Disclosure Project'),(81,'CareerShift LLC'),(82,'CCH Incorporated'),(83,'Centro de Investigaciones Sociologicas'),(84,'Chemical Abstracts Service (CAS)'),(85,'Chiniquy Collection'),(86,'Chorus America'),(87,'Chronicle of Higher Education'),(88,'Colegio de Mexico'),(89,'College Art Association'),(90,'Company of Biologists Ltd'),(91,'Competitive Media Reporting, LLC (TNS Media Intelligence TNSMI)'),(92,'Consejo Superior de Investigaciones Cientificas (CSIC)'),(93,'Consumer Electronics Association'),(94,'Cornell University Library'),(95,'Corporacion Latinobarometro'),(96,'Corporation for National Research Initiatives (CNRI)'),(97,'CQ Press'),(98,'CSIRO Publishing'),(99,'Current History, Inc'),(100,'Dialog'),(101,'Dialogue Foundation'),(102,'Digital Distributed Community Archive'),(103,'Digital Heritage Publishing Limited'),(104,'Duke University Press'),(105,'Dun and Bradstreet Inc'),(106,'Dunstans Publishing Ltd'),(107,'East View Information Services'),(108,'EBSCO'),(109,'Ecological Society of America'),(110,'Edinburgh University Press'),(111,'EDP Sciences'),(112,'Elsevier'),(113,'Encyclopaedia Britannica Online'),(114,'Endocrine Society'),(115,'Entomological Society of Canada'),(116,'Equinox Publishing Ltd'),(117,'European Mathematical Society Publishing House'),(118,'European Society of Endocrinology'),(119,'Evolutionary Ecology Ltd'),(120,'ExLibris'),(121,'Experian Marketing Solutions, Inc.'),(122,'FamilyLink.com, Inc.'),(123,'FamilyLink.com, Inc.'),(124,'Faulkner Information Services'),(125,'Federation of American Societies for Experimental Biology'),(126,'Forrester Research, Inc'),(127,'Franz Steiner Verlag'),(128,'Genetics Society of America'),(129,'Geographic Research, Inc'),(130,'GeoScienceWorld'),(131,'Global Science Press'),(132,'Grove Dictionaries, Inc'),(133,'GuideStar USA, Inc'),(134,'H.W. Wilson Company'),(135,'H1 Base, Inc'),(136,'Hans Zell Publishing'),(137,'Haworth Press'),(138,'Heldref Publications'),(139,'HighWire Press'),(140,'Histochemical Society'),(141,'Human Kinetics Inc.'),(142,'IBISWorld USA'),(143,'Idea Group Inc'),(144,'IEEE'),(145,'Incisive Media Ltd'),(146,'Indiana University Mathematics Journal'),(147,'Informa Healthcare USA, Inc'),(148,'Information Resources, Inc'),(149,'INFORMS'),(150,'Ingentaconnect'),(151,'Institute of Mathematics of the Polish Academy of Sciences'),(152,'Institute of Physics (IOP)'),(153,'Institution of Engineering and Technology (IET)'),(154,'Institutional Shareholder Services Inc'),(155,'InteLex'),(156,'Intellect'),(157,'Intelligence Research Limited'),(158,'International Press'),(159,'IOS Press'),(160,'IPA Source, LLC'),(161,'Irish Newspaper Archives Ltd'),(162,'ITHAKA'),(163,'IVES Group, Inc'),(164,'Japan Focus'),(165,'John Benjamins Publishing Company'),(166,'JSTOR'),(167,'Karger'),(168,'Keesings Worldwide, LLC'),(169,'KLD Research and Analytics Inc'),(170,'Landes Bioscience'),(171,'LexisNexis'),(172,'Librairie Droz'),(173,'Library of Congress, Cataloging Distribution Service'),(174,'Lipper Inc'),(175,'Liverpool University Press'),(176,'Lord Music Reference Inc'),(177,'M.E. Sharpe, Inc'),(178,'Manchester University Press'),(179,'Marine Biological Laboratory'),(180,'MarketResearch.com, Inc'),(181,'Marquis Who\'s Who LLC'),(182,'Mary Ann Liebert, Inc'),(183,'Massachusetts Medical Society'),(184,'Mathematical Sciences Publishers'),(185,'Mediamark Research and Intelligence, LLC'),(186,'Mergent, Inc'),(187,'Metropolitan Opera'),(188,'Mintel International Group Limited'),(189,'MIT Press'),(190,'MIT'),(191,'Morningstar Inc.'),(192,'National Academy of Sciences'),(193,'National Gallery Company Ltd'),(194,'National Research Council of Canada'),(195,'Nature Publishing Group'),(196,'Naxos Digital Services Limited'),(197,'Neilson Journals Publishing'),(198,'New York Review of Books'),(199,'NewsBank, Inc'),(200,'OCLC'),(201,'Otto Harrassowitz'),(202,'Ovid'),(203,'Oxford Centre of Hebrew and Jewish Studies'),(204,'Oxford University Press'),(205,'Paradigm Publishers'),(206,'Paratext'),(207,'Peeters Publishers'),(208,'Philosophy Documentation Center'),(209,'Portland Press Limited'),(210,'Preservation Technologies LP'),(211,'Project Muse'),(212,'ProQuest LLC'),(213,'Psychoanalytic Electronic Publishing Inc'),(214,'R.R. Bowker'),(215,'Religious and Theological Abstracts, Inc'),(216,'Reuters Loan Pricing Corporation'),(217,'Risk Management Association (RMA)'),(218,'Rivista di Studi italiani'),(219,'Robert Blakemore'),(220,'Rockefeller University Press'),(221,'Roper Center for Public Opinion Research'),(222,'Royal Society of Chemistry'),(223,'Royal Society of London'),(224,'SAGE Publications'),(225,'Scholarly Digital Editions'),(226,'Seminario Matematico of the University of Padua'),(227,'Simmons Market Research Bureau Inc'),(228,'SISMEL - Edizioni del Galluzzo'),(229,'Social Explorer'),(230,'Societe Mathematique de France'),(231,'Society for Endocrinology'),(232,'Society for Experimental Biology and Medicine'),(233,'Society for General Microbiology'),(234,'Society for Industrial and Applied Mathematics (SIAM)'),(235,'Society for Leukocyte Biology'),(236,'Society for Neuroscience'),(237,'Society for Reproduction and Fertility'),(238,'Society of Antiquaries of Scotland'),(239,'Society of Environmental Toxicology and Chemistry'),(240,'SPIE'),(241,'Springer'),(242,'Standard and Poor\'s'),(243,'Stanford University'),(244,'Swank Motion Pictures, Inc'),(245,'Swiss Chemical Society'),(246,'Tablet Publishing (London)'),(247,'Taylor and Francis'),(248,'Teachers College Record'),(249,'Terra Scientific Publishing Company'),(250,'Tetrad Computer Applications Inc'),(251,'The Academy of the Hebrew Language'),(252,'Thesaurus Linguae Graecae'),(253,'Thomas Telford Ltd'),(254,'Thomson Financial Inc'),(255,'Thomson Gale'),(256,'Thomson RIA'),(257,'Thomson Scientific Inc. (Institute for Scientific Information, Inc.)'),(258,'Trans Tech Publications'),(259,'Transportation Research Board'),(260,'U.S. Department of Commerce'),(261,'UCLA Chicano Studies Research Center Press'),(262,'University of Barcelona'),(263,'University of Buckingham Press'),(264,'University of California Press'),(265,'University of Chicago Press'),(266,'University of Houston Department of Mathematics'),(267,'University of Illinois Press'),(268,'University of Iowa'),(269,'University of Pittsburgh'),(270,'University of Toronto Press Inc'),(271,'University of Toronto'),(272,'University of Virginia Press'),(273,'University of Wisconsin Press'),(274,'Universum USA'),(275,'Uniworld Business Publications, Inc'),(276,'Value Line, Inc'),(277,'Vanderbilt University'),(278,'Vault, Inc'),(279,'Verlag C.H. Beck'),(280,'Verlag der Zeitschrift fur Naturforschung '),(281,'W.S. Maney and Son Ltd'),(282,'Walter de Gruyter'),(283,'White Horse Press'),(284,'Wiley'),(285,'World Scientific'),(286,'World Trade Press'),(287,'Worldwatch Institute'),(288,'Yankelovich Inc');
+/*!40000 ALTER TABLE `Organization` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Privilege`
+--
+
+DROP TABLE IF EXISTS `Privilege`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Privilege` (
+  `privilegeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`privilegeID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Privilege`
+--
+
+LOCK TABLES `Privilege` WRITE;
+/*!40000 ALTER TABLE `Privilege` DISABLE KEYS */;
+INSERT INTO `Privilege` VALUES (1,'admin'),(2,'add/edit'),(3,'view only'),(4,'restricted');
+/*!40000 ALTER TABLE `Privilege` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Qualifier`
+--
+
+DROP TABLE IF EXISTS `Qualifier`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Qualifier` (
+  `qualifierID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `expressionTypeID` int(10) unsigned NOT NULL,
+  `shortName` varchar(45) NOT NULL,
+  PRIMARY KEY (`qualifierID`),
+  KEY `expressionTypeID` (`expressionTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=9 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Qualifier`
+--
+
+LOCK TABLES `Qualifier` WRITE;
+/*!40000 ALTER TABLE `Qualifier` DISABLE KEYS */;
+INSERT INTO `Qualifier` VALUES (1,2,'Not Clear'),(2,2,'Not Reviewed'),(3,2,'Prohibited'),(4,2,'Permitted'),(5,3,'Not Clear'),(6,3,'Not Reviewed'),(7,3,'Prohibited'),(8,3,'Permitted');
+/*!40000 ALTER TABLE `Qualifier` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `SFXProvider`
+--
+
+DROP TABLE IF EXISTS `SFXProvider`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SFXProvider` (
+  `sfxProviderID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `shortName` varchar(245) NOT NULL,
+  PRIMARY KEY (`sfxProviderID`),
+  KEY `documentID` (`documentID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `SFXProvider`
+--
+
+LOCK TABLES `SFXProvider` WRITE;
+/*!40000 ALTER TABLE `SFXProvider` DISABLE KEYS */;
+/*!40000 ALTER TABLE `SFXProvider` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Signature`
+--
+
+DROP TABLE IF EXISTS `Signature`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Signature` (
+  `signatureID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `signatureTypeID` int(10) unsigned NOT NULL,
+  `signatureDate` date DEFAULT NULL,
+  `signerName` tinytext,
+  PRIMARY KEY (`signatureID`),
+  KEY `documentID` (`documentID`),
+  KEY `signatureTypeID` (`signatureTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Signature`
+--
+
+LOCK TABLES `Signature` WRITE;
+/*!40000 ALTER TABLE `Signature` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Signature` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `SignatureType`
+--
+
+DROP TABLE IF EXISTS `SignatureType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SignatureType` (
+  `signatureTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`signatureTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `SignatureType`
+--
+
+LOCK TABLES `SignatureType` WRITE;
+/*!40000 ALTER TABLE `SignatureType` DISABLE KEYS */;
+INSERT INTO `SignatureType` VALUES (1,'Agent'),(2,'Consortium'),(3,'Internal'),(4,'Provider');
+/*!40000 ALTER TABLE `SignatureType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Status`
+--
+
+DROP TABLE IF EXISTS `Status`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Status` (
+  `statusID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) NOT NULL,
+  PRIMARY KEY (`statusID`)
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Status`
+--
+
+LOCK TABLES `Status` WRITE;
+/*!40000 ALTER TABLE `Status` DISABLE KEYS */;
+INSERT INTO `Status` VALUES (1,'Awaiting Document'),(2,'Complete'),(3,'Document Only'),(4,'Editing Expressions'),(5,'NLR');
+/*!40000 ALTER TABLE `Status` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL,
+  `lastName` varchar(45) DEFAULT NULL,
+  `firstName` varchar(45) DEFAULT NULL,
+  `privilegeID` int(10) unsigned DEFAULT NULL,
+  `emailAddressForTermsTool` varchar(150) DEFAULT NULL,
+  PRIMARY KEY (`loginID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test',NULL,NULL,1,NULL);
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_management_test`
+--
+
+USE `coral_management_test`;
+
+--
+-- Table structure for table `Attachment`
+--
+
+DROP TABLE IF EXISTS `Attachment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Attachment` (
+  `attachmentID` int(10) NOT NULL AUTO_INCREMENT,
+  `licenseID` int(10) DEFAULT NULL,
+  `sentDate` date DEFAULT NULL,
+  `attachmentText` text,
+  PRIMARY KEY (`attachmentID`),
+  KEY `licenseID` (`licenseID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Attachment`
+--
+
+LOCK TABLES `Attachment` WRITE;
+/*!40000 ALTER TABLE `Attachment` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Attachment` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AttachmentFile`
+--
+
+DROP TABLE IF EXISTS `AttachmentFile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AttachmentFile` (
+  `attachmentFileID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `attachmentID` int(10) unsigned NOT NULL,
+  `attachmentURL` varchar(200) NOT NULL,
+  PRIMARY KEY (`attachmentFileID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AttachmentFile`
+--
+
+LOCK TABLES `AttachmentFile` WRITE;
+/*!40000 ALTER TABLE `AttachmentFile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `AttachmentFile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Consortium`
+--
+
+DROP TABLE IF EXISTS `Consortium`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Consortium` (
+  `consortiumID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`consortiumID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Consortium`
+--
+
+LOCK TABLES `Consortium` WRITE;
+/*!40000 ALTER TABLE `Consortium` DISABLE KEYS */;
+INSERT INTO `Consortium` VALUES (1,'CORAL Documentation');
+/*!40000 ALTER TABLE `Consortium` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Document`
+--
+
+DROP TABLE IF EXISTS `Document`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Document` (
+  `documentID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  `documentTypeID` int(10) unsigned NOT NULL,
+  `licenseID` int(10) unsigned NOT NULL,
+  `effectiveDate` date DEFAULT NULL,
+  `expirationDate` date DEFAULT NULL,
+  `documentURL` varchar(200) DEFAULT NULL,
+  `parentDocumentID` int(10) unsigned DEFAULT NULL,
+  `description` tinytext,
+  `revisionDate` date DEFAULT NULL,
+  PRIMARY KEY (`documentID`),
+  KEY `licenseID` (`licenseID`),
+  KEY `documentTypeID` (`documentTypeID`),
+  KEY `parentDocumentID` (`parentDocumentID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Document`
+--
+
+LOCK TABLES `Document` WRITE;
+/*!40000 ALTER TABLE `Document` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Document` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DocumentNote`
+--
+
+DROP TABLE IF EXISTS `DocumentNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DocumentNote` (
+  `documentNoteID` int(11) NOT NULL AUTO_INCREMENT,
+  `licenseID` int(11) NOT NULL,
+  `documentID` int(11) DEFAULT '0',
+  `documentNoteTypeID` int(11) NOT NULL,
+  `body` text NOT NULL,
+  `createDate` datetime NOT NULL,
+  PRIMARY KEY (`documentNoteID`),
+  KEY `licenseID` (`licenseID`,`documentNoteTypeID`),
+  KEY `documentID` (`documentID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DocumentNote`
+--
+
+LOCK TABLES `DocumentNote` WRITE;
+/*!40000 ALTER TABLE `DocumentNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `DocumentNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DocumentNoteType`
+--
+
+DROP TABLE IF EXISTS `DocumentNoteType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DocumentNoteType` (
+  `documentNoteTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(60) NOT NULL,
+  PRIMARY KEY (`documentNoteTypeID`)
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DocumentNoteType`
+--
+
+LOCK TABLES `DocumentNoteType` WRITE;
+/*!40000 ALTER TABLE `DocumentNoteType` DISABLE KEYS */;
+INSERT INTO `DocumentNoteType` VALUES (9,'General');
+/*!40000 ALTER TABLE `DocumentNoteType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DocumentType`
+--
+
+DROP TABLE IF EXISTS `DocumentType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DocumentType` (
+  `documentTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`documentTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DocumentType`
+--
+
+LOCK TABLES `DocumentType` WRITE;
+/*!40000 ALTER TABLE `DocumentType` DISABLE KEYS */;
+INSERT INTO `DocumentType` VALUES (1,'Checklist');
+/*!40000 ALTER TABLE `DocumentType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Expression`
+--
+
+DROP TABLE IF EXISTS `Expression`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Expression` (
+  `expressionID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `expressionTypeID` int(10) unsigned NOT NULL,
+  `documentText` text,
+  `simplifiedText` text,
+  `lastUpdateDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `productionUseInd` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`expressionID`),
+  KEY `documentID` (`documentID`),
+  KEY `expressionTypeID` (`expressionTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Expression`
+--
+
+LOCK TABLES `Expression` WRITE;
+/*!40000 ALTER TABLE `Expression` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Expression` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionNote`
+--
+
+DROP TABLE IF EXISTS `ExpressionNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionNote` (
+  `expressionNoteID` int(10) NOT NULL AUTO_INCREMENT,
+  `expressionID` int(10) DEFAULT NULL,
+  `note` varchar(2000) DEFAULT NULL,
+  `displayOrderSeqNumber` int(10) DEFAULT NULL,
+  `lastUpdateDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`expressionNoteID`),
+  KEY `expressionID` (`expressionID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionNote`
+--
+
+LOCK TABLES `ExpressionNote` WRITE;
+/*!40000 ALTER TABLE `ExpressionNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExpressionNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionQualifierProfile`
+--
+
+DROP TABLE IF EXISTS `ExpressionQualifierProfile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionQualifierProfile` (
+  `expressionID` int(10) unsigned NOT NULL,
+  `qualifierID` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`expressionID`,`qualifierID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionQualifierProfile`
+--
+
+LOCK TABLES `ExpressionQualifierProfile` WRITE;
+/*!40000 ALTER TABLE `ExpressionQualifierProfile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExpressionQualifierProfile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExpressionType`
+--
+
+DROP TABLE IF EXISTS `ExpressionType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExpressionType` (
+  `expressionTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  `noteType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`expressionTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExpressionType`
+--
+
+LOCK TABLES `ExpressionType` WRITE;
+/*!40000 ALTER TABLE `ExpressionType` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExpressionType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `License`
+--
+
+DROP TABLE IF EXISTS `License`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `License` (
+  `licenseID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `consortiumID` int(10) unsigned DEFAULT NULL,
+  `organizationID` int(10) unsigned DEFAULT NULL,
+  `shortName` tinytext NOT NULL,
+  `statusID` int(10) unsigned DEFAULT NULL,
+  `statusDate` datetime DEFAULT NULL,
+  `createDate` datetime DEFAULT NULL,
+  `typeID` int(11) DEFAULT NULL,
+  `description` varchar(200) DEFAULT NULL,
+  `statusLoginID` varchar(50) DEFAULT NULL,
+  `createLoginID` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`licenseID`),
+  KEY `organizationID` (`organizationID`),
+  KEY `consortiumID` (`consortiumID`),
+  KEY `statusID` (`statusID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `License`
+--
+
+LOCK TABLES `License` WRITE;
+/*!40000 ALTER TABLE `License` DISABLE KEYS */;
+/*!40000 ALTER TABLE `License` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Organization`
+--
+
+DROP TABLE IF EXISTS `Organization`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Organization` (
+  `organizationID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`organizationID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Organization`
+--
+
+LOCK TABLES `Organization` WRITE;
+/*!40000 ALTER TABLE `Organization` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Organization` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Privilege`
+--
+
+DROP TABLE IF EXISTS `Privilege`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Privilege` (
+  `privilegeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`privilegeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Privilege`
+--
+
+LOCK TABLES `Privilege` WRITE;
+/*!40000 ALTER TABLE `Privilege` DISABLE KEYS */;
+INSERT INTO `Privilege` VALUES (1,'admin'),(2,'add/edit'),(3,'view only');
+/*!40000 ALTER TABLE `Privilege` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Qualifier`
+--
+
+DROP TABLE IF EXISTS `Qualifier`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Qualifier` (
+  `qualifierID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `expressionTypeID` int(10) unsigned NOT NULL,
+  `shortName` varchar(45) NOT NULL,
+  PRIMARY KEY (`qualifierID`),
+  KEY `expressionTypeID` (`expressionTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Qualifier`
+--
+
+LOCK TABLES `Qualifier` WRITE;
+/*!40000 ALTER TABLE `Qualifier` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Qualifier` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `SFXProvider`
+--
+
+DROP TABLE IF EXISTS `SFXProvider`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SFXProvider` (
+  `sfxProviderID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `shortName` varchar(245) NOT NULL,
+  PRIMARY KEY (`sfxProviderID`),
+  KEY `documentID` (`documentID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `SFXProvider`
+--
+
+LOCK TABLES `SFXProvider` WRITE;
+/*!40000 ALTER TABLE `SFXProvider` DISABLE KEYS */;
+/*!40000 ALTER TABLE `SFXProvider` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Signature`
+--
+
+DROP TABLE IF EXISTS `Signature`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Signature` (
+  `signatureID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `documentID` int(10) unsigned NOT NULL,
+  `signatureTypeID` int(10) unsigned NOT NULL,
+  `signatureDate` date DEFAULT NULL,
+  `signerName` tinytext,
+  PRIMARY KEY (`signatureID`),
+  KEY `documentID` (`documentID`),
+  KEY `signatureTypeID` (`signatureTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Signature`
+--
+
+LOCK TABLES `Signature` WRITE;
+/*!40000 ALTER TABLE `Signature` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Signature` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `SignatureType`
+--
+
+DROP TABLE IF EXISTS `SignatureType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SignatureType` (
+  `signatureTypeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`signatureTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `SignatureType`
+--
+
+LOCK TABLES `SignatureType` WRITE;
+/*!40000 ALTER TABLE `SignatureType` DISABLE KEYS */;
+/*!40000 ALTER TABLE `SignatureType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Status`
+--
+
+DROP TABLE IF EXISTS `Status`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Status` (
+  `statusID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) NOT NULL,
+  PRIMARY KEY (`statusID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Status`
+--
+
+LOCK TABLES `Status` WRITE;
+/*!40000 ALTER TABLE `Status` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Status` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Type`
+--
+
+DROP TABLE IF EXISTS `Type`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Type` (
+  `typeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`typeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Type`
+--
+
+LOCK TABLES `Type` WRITE;
+/*!40000 ALTER TABLE `Type` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Type` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL,
+  `lastName` varchar(45) DEFAULT NULL,
+  `firstName` varchar(45) DEFAULT NULL,
+  `privilegeID` int(10) unsigned DEFAULT NULL,
+  `emailAddressForTermsTool` varchar(150) DEFAULT NULL,
+  PRIMARY KEY (`loginID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test',NULL,NULL,1,NULL);
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `license_consortium`
+--
+
+DROP TABLE IF EXISTS `license_consortium`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `license_consortium` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `licenseID` int(11) DEFAULT NULL,
+  `consortiumID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='							';
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `license_consortium`
+--
+
+LOCK TABLES `license_consortium` WRITE;
+/*!40000 ALTER TABLE `license_consortium` DISABLE KEYS */;
+/*!40000 ALTER TABLE `license_consortium` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_organizations_test`
+--
+
+USE `coral_organizations_test`;
+
+--
+-- Table structure for table `Alias`
+--
+
+DROP TABLE IF EXISTS `Alias`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Alias` (
+  `aliasID` int(11) NOT NULL AUTO_INCREMENT,
+  `organizationID` int(11) DEFAULT NULL,
+  `aliasTypeID` int(11) DEFAULT NULL,
+  `name` varchar(150) NOT NULL,
+  PRIMARY KEY (`aliasID`),
+  UNIQUE KEY `aliasID` (`aliasID`),
+  KEY `organizationID` (`organizationID`),
+  KEY `aliasTypeID` (`aliasTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=123 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Alias`
+--
+
+LOCK TABLES `Alias` WRITE;
+/*!40000 ALTER TABLE `Alias` DISABLE KEYS */;
+INSERT INTO `Alias` VALUES (1,2,3,'IOP'),(2,3,3,'AIAA'),(3,4,3,'APS'),(4,5,3,'ASCE'),(5,6,3,'AIP'),(6,7,3,'SIAM'),(7,9,3,'CAS'),(8,10,3,'RMA'),(9,11,3,'ACI'),(10,12,3,'AACR'),(11,13,3,'IET'),(12,14,3,'AEA'),(13,15,3,'AMS'),(14,16,3,'AMA'),(15,35,2,'Thomson Gale'),(16,18,3,'CSIC'),(17,19,3,'AMS'),(18,20,3,'ALA'),(19,21,3,'ASTM'),(20,22,3,'ARL'),(21,23,3,'ASLO'),(22,25,3,'APA'),(23,26,3,'ACLS'),(24,27,3,'AAAS'),(25,265,3,'CEA'),(26,141,3,'L/N'),(27,270,3,'CSA'),(28,305,3,'ACM'),(29,306,3,'ACS'),(30,8,2,'Competitive Media Reporting, LLC'),(31,28,1,'Thomson ISI'),(32,53,3,'AccuNet'),(33,271,3,'AICPA'),(34,311,2,'American Association on Mental Retardation'),(35,311,3,'AAMR'),(36,311,3,'AAIDD'),(37,46,3,'AFS'),(38,32,3,'AGU'),(39,245,3,'APPI'),(40,244,3,'ASCB'),(41,242,3,'ASHS'),(42,312,3,'ASM'),(43,314,3,'ASME'),(44,401,3,'WWP'),(45,236,3,'ASA'),(46,224,3,'BE Press'),(47,180,3,'FASEB'),(48,177,3,'GSA'),(49,163,3,'HCS'),(50,134,3,'MBL'),(51,104,3,'RSC'),(52,96,3,'SEBM'),(53,95,3,'SGM'),(54,94,3,'SLB'),(55,93,3,'SfN'),(56,82,3,'TTP'),(57,61,1,'Institute of Electrical and Electronics Engineers'),(58,171,3,'AIC'),(59,276,3,'AAR'),(60,273,3,'ACA'),(61,322,3,'AIMS'),(62,214,3,'CCDC'),(63,362,3,'CIAO'),(64,363,3,'CNRI'),(65,366,3,'GSA'),(66,368,3,'IPAP'),(67,371,3,'MLA'),(68,372,3,'OSA'),(69,380,3,'PS'),(70,257,1,'Atypon Link'),(71,383,3,'SAE'),(72,41,1,'Caliber'),(73,59,3,'CUP'),(74,193,3,'EUP'),(75,365,1,'Insight'),(76,386,3,'LEA'),(77,372,1,'OpticsInfoBase'),(78,116,1,'POJ'),(79,113,1,'Sirius'),(80,255,3,'MIT'),(81,206,3,'CDP'),(82,317,3,'CRL'),(83,88,1,'Society of Photo-optical Instrumentation Engineers'),(84,279,1,'Simmons Market Research Bureau'),(85,404,1,'Society of Environmental Toxicology and Chemistry '),(86,405,1,'oldenbourg-link'),(87,415,1,'Otto Harrassowitz'),(88,259,2,'Thomson RIA'),(89,28,2,'Thomson Scientific'),(90,418,3,'HRAF'),(91,399,1,'ReferenceUSA'),(92,254,1,'Audit Analytics'),(93,159,2,'Idea Group Inc'),(94,87,3,'S&P'),(95,422,1,'Morgan Stanley Capital International'),(96,420,2,'RiskMetrics Group'),(97,267,3,'ISS'),(98,120,3,'Readex'),(99,425,1,'Center for the Advancement of the Research Methods and Analysis'),(100,305,1,'ACM Digital Library'),(101,426,3,'MCLS'),(102,426,2,'MLC'),(103,426,2,'Michigan Library Consortia'),(104,426,2,'INCOLSA'),(105,427,3,'PLoS'),(106,400,1,'R.R. Bowker'),(107,429,3,'UNIDO'),(108,434,3,'BAS'),(109,35,1,'APG: Academic and Professional Group'),(110,44,2,'Silverplatter'),(111,44,1,'OvidSP'),(112,122,1,'Naxos Digital Services Ltd'),(113,37,3,'OUP'),(114,475,3,'OECD'),(115,194,3,'ESA'),(116,173,1,'H1Base'),(117,28,1,'ISI'),(118,484,1,'Austrian Academy of Sciences Press'),(119,485,3,'ARM'),(120,485,1,'New World Records'),(121,490,1,'CDI Systems Ltd.'),(122,399,2,'infogroup');
+/*!40000 ALTER TABLE `Alias` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AliasType`
+--
+
+DROP TABLE IF EXISTS `AliasType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AliasType` (
+  `aliasTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`aliasTypeID`),
+  UNIQUE KEY `aliasTypeID` (`aliasTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AliasType`
+--
+
+LOCK TABLES `AliasType` WRITE;
+/*!40000 ALTER TABLE `AliasType` DISABLE KEYS */;
+INSERT INTO `AliasType` VALUES (1,'Alternate Name'),(2,'Name Change'),(3,'Acronym');
+/*!40000 ALTER TABLE `AliasType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Contact`
+--
+
+DROP TABLE IF EXISTS `Contact`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Contact` (
+  `contactID` int(11) NOT NULL AUTO_INCREMENT,
+  `organizationID` int(11) NOT NULL,
+  `lastUpdateDate` date DEFAULT NULL,
+  `name` varchar(150) DEFAULT NULL,
+  `title` varchar(150) DEFAULT NULL,
+  `addressText` varchar(300) DEFAULT NULL,
+  `phoneNumber` varchar(50) DEFAULT NULL,
+  `altPhoneNumber` varchar(50) DEFAULT NULL,
+  `faxNumber` varchar(50) DEFAULT NULL,
+  `emailAddress` varchar(100) DEFAULT NULL,
+  `archiveDate` date DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`contactID`),
+  UNIQUE KEY `contactID` (`contactID`),
+  KEY `organizationID` (`organizationID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Contact`
+--
+
+LOCK TABLES `Contact` WRITE;
+/*!40000 ALTER TABLE `Contact` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Contact` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ContactRole`
+--
+
+DROP TABLE IF EXISTS `ContactRole`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ContactRole` (
+  `contactRoleID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`contactRoleID`),
+  UNIQUE KEY `contactRoleID` (`contactRoleID`)
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ContactRole`
+--
+
+LOCK TABLES `ContactRole` WRITE;
+/*!40000 ALTER TABLE `ContactRole` DISABLE KEYS */;
+INSERT INTO `ContactRole` VALUES (1,'Accounting'),(2,'Licensing'),(3,'Sales'),(4,'Support'),(5,'Training');
+/*!40000 ALTER TABLE `ContactRole` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ContactRoleProfile`
+--
+
+DROP TABLE IF EXISTS `ContactRoleProfile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ContactRoleProfile` (
+  `contactID` int(10) unsigned NOT NULL,
+  `contactRoleID` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`contactID`,`contactRoleID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ContactRoleProfile`
+--
+
+LOCK TABLES `ContactRoleProfile` WRITE;
+/*!40000 ALTER TABLE `ContactRoleProfile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ContactRoleProfile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExternalLogin`
+--
+
+DROP TABLE IF EXISTS `ExternalLogin`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExternalLogin` (
+  `externalLoginID` int(11) NOT NULL AUTO_INCREMENT,
+  `organizationID` int(11) DEFAULT NULL,
+  `externalLoginTypeID` int(11) DEFAULT NULL,
+  `updateDate` date DEFAULT NULL,
+  `loginURL` varchar(150) DEFAULT NULL,
+  `emailAddress` varchar(150) DEFAULT NULL,
+  `username` varchar(50) DEFAULT NULL,
+  `password` varchar(50) DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`externalLoginID`),
+  UNIQUE KEY `externalLoginID` (`externalLoginID`),
+  KEY `organizationID` (`organizationID`),
+  KEY `externalLoginTypeID` (`externalLoginTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExternalLogin`
+--
+
+LOCK TABLES `ExternalLogin` WRITE;
+/*!40000 ALTER TABLE `ExternalLogin` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExternalLogin` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExternalLoginType`
+--
+
+DROP TABLE IF EXISTS `ExternalLoginType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExternalLoginType` (
+  `externalLoginTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`externalLoginTypeID`),
+  UNIQUE KEY `externalLoginTypeID` (`externalLoginTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExternalLoginType`
+--
+
+LOCK TABLES `ExternalLoginType` WRITE;
+/*!40000 ALTER TABLE `ExternalLoginType` DISABLE KEYS */;
+INSERT INTO `ExternalLoginType` VALUES (1,'Admin'),(2,'FTP'),(3,'Other'),(4,'Statistics'),(5,'Support');
+/*!40000 ALTER TABLE `ExternalLoginType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueLog`
+--
+
+DROP TABLE IF EXISTS `IssueLog`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueLog` (
+  `issueLogID` int(11) NOT NULL AUTO_INCREMENT,
+  `organizationID` int(11) DEFAULT NULL,
+  `issueLogTypeID` int(11) DEFAULT NULL,
+  `updateDate` date DEFAULT NULL,
+  `updateLoginID` varchar(50) DEFAULT NULL,
+  `issueStartDate` date DEFAULT NULL,
+  `issueEndDate` date DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`issueLogID`),
+  UNIQUE KEY `issueLogID` (`issueLogID`),
+  KEY `organizationID` (`organizationID`),
+  KEY `issueLogTypeID` (`issueLogTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueLog`
+--
+
+LOCK TABLES `IssueLog` WRITE;
+/*!40000 ALTER TABLE `IssueLog` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueLog` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueLogType`
+--
+
+DROP TABLE IF EXISTS `IssueLogType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueLogType` (
+  `issueLogTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`issueLogTypeID`),
+  UNIQUE KEY `issueLogTypeID` (`issueLogTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueLogType`
+--
+
+LOCK TABLES `IssueLogType` WRITE;
+/*!40000 ALTER TABLE `IssueLogType` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueLogType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Organization`
+--
+
+DROP TABLE IF EXISTS `Organization`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Organization` (
+  `organizationID` int(11) NOT NULL AUTO_INCREMENT,
+  `createDate` date DEFAULT NULL,
+  `createLoginID` varchar(50) DEFAULT NULL,
+  `updateDate` date DEFAULT NULL,
+  `updateLoginID` varchar(50) DEFAULT NULL,
+  `name` varchar(150) DEFAULT NULL,
+  `companyURL` varchar(150) DEFAULT NULL,
+  `noteText` text,
+  `accountDetailText` text,
+  PRIMARY KEY (`organizationID`),
+  UNIQUE KEY `organizationID` (`organizationID`)
+) ENGINE=MyISAM AUTO_INCREMENT=505 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Organization`
+--
+
+LOCK TABLES `Organization` WRITE;
+/*!40000 ALTER TABLE `Organization` DISABLE KEYS */;
+INSERT INTO `Organization` VALUES (2,'2016-09-09','system',NULL,NULL,'Institute of Physics',NULL,NULL,NULL),(3,'2016-09-09','system',NULL,NULL,'American Institute of Aeronautics and Astronautics',NULL,NULL,NULL),(4,'2016-09-09','system',NULL,NULL,'American Physical Society',NULL,NULL,NULL),(5,'2016-09-09','system',NULL,NULL,'American Society of Civil Engineers',NULL,NULL,NULL),(6,'2016-09-09','system',NULL,NULL,'American Insitute of Physics',NULL,NULL,NULL),(7,'2016-09-09','system',NULL,NULL,'Society for Industrial and Applied Mathematics',NULL,NULL,NULL),(8,'2016-09-09','system',NULL,NULL,'TNS Media Intelligence',NULL,NULL,NULL),(9,'2016-09-09','system',NULL,NULL,'Chemical Abstracts Service',NULL,NULL,NULL),(10,'2016-09-09','system',NULL,NULL,'Risk Management Association',NULL,NULL,NULL),(11,'2016-09-09','system',NULL,NULL,'American Concrete Institute',NULL,NULL,NULL),(12,'2016-09-09','system',NULL,NULL,'American Association for Cancer Research',NULL,NULL,NULL),(13,'2016-09-09','system',NULL,NULL,'Institution of Engineering and Technology',NULL,NULL,NULL),(14,'2016-09-09','system',NULL,NULL,'American Economic Association',NULL,NULL,NULL),(15,'2016-09-09','system',NULL,NULL,'American Mathematical Society',NULL,NULL,NULL),(16,'2016-09-09','system',NULL,NULL,'American Medical Association',NULL,NULL,NULL),(18,'2016-09-09','system',NULL,NULL,'Consejo Superior de Investigaciones Cientificas',NULL,NULL,NULL),(19,'2016-09-09','system',NULL,NULL,'American Meteorological Society',NULL,NULL,NULL),(20,'2016-09-09','system',NULL,NULL,'American Library Association',NULL,NULL,NULL),(21,'2016-09-09','system',NULL,NULL,'American Society for Testing and Materials',NULL,NULL,NULL),(22,'2016-09-09','system',NULL,NULL,'Association of Research Libraries',NULL,NULL,NULL),(23,'2016-09-09','system',NULL,NULL,'American Society of Limnology and Oceanography',NULL,NULL,NULL),(24,'2016-09-09','system',NULL,NULL,'Tablet Publishing',NULL,NULL,NULL),(25,'2016-09-09','system',NULL,NULL,'American Psychological Association',NULL,NULL,NULL),(26,'2016-09-09','system',NULL,NULL,'American Council of Learned Societies',NULL,NULL,NULL),(27,'2016-09-09','system',NULL,NULL,'American Association for the Advancement of Science',NULL,NULL,NULL),(28,'2016-09-09','system',NULL,NULL,'Thomson Healthcare and Science',NULL,NULL,NULL),(29,'2016-09-09','system',NULL,NULL,'Elsevier',NULL,NULL,NULL),(30,'2016-09-09','system',NULL,NULL,'JSTOR',NULL,NULL,NULL),(31,'2016-09-09','system',NULL,NULL,'SAGE Publications',NULL,NULL,NULL),(32,'2016-09-09','system',NULL,NULL,'American Geophysical Union',NULL,NULL,NULL),(33,'2016-09-09','system',NULL,NULL,'Annual Reviews',NULL,NULL,NULL),(34,'2016-09-09','system',NULL,NULL,'BioOne',NULL,NULL,NULL),(35,'2016-09-09','system',NULL,NULL,'Gale',NULL,NULL,NULL),(36,'2016-09-09','system',NULL,NULL,'Wiley',NULL,NULL,NULL),(37,'2016-09-09','system',NULL,NULL,'Oxford University Press',NULL,NULL,NULL),(38,'2016-09-09','system',NULL,NULL,'Springer',NULL,NULL,NULL),(39,'2016-09-09','system',NULL,NULL,'Taylor and Francis',NULL,NULL,NULL),(40,'2016-09-09','system',NULL,NULL,'Stanford University',NULL,NULL,NULL),(41,'2016-09-09','system',NULL,NULL,'University of California Press',NULL,NULL,NULL),(42,'2016-09-09','system',NULL,NULL,'EBSCO Publishing',NULL,NULL,NULL),(43,'2016-09-09','system',NULL,NULL,'Blackwell Publishing',NULL,NULL,NULL),(44,'2016-09-09','system',NULL,NULL,'Ovid',NULL,NULL,NULL),(45,'2016-09-09','system',NULL,NULL,'Project Muse',NULL,NULL,NULL),(46,'2016-09-09','system',NULL,NULL,'American Fisheries Society',NULL,NULL,NULL),(47,'2016-09-09','system',NULL,NULL,'Neilson Journals Publishing',NULL,NULL,NULL),(48,'2016-09-09','system',NULL,NULL,'GuideStar USA, Inc',NULL,NULL,NULL),(49,'2016-09-09','system',NULL,NULL,'Alexander Street Press, LLC',NULL,NULL,NULL),(50,'2016-09-09','system',NULL,NULL,'Informa Healthcare USA, Inc',NULL,NULL,NULL),(51,'2016-09-09','system',NULL,NULL,'ProQuest LLC',NULL,NULL,NULL),(52,'2016-09-09','system',NULL,NULL,'Accessible Archives Inc',NULL,NULL,NULL),(53,'2016-09-09','system',NULL,NULL,'ACCU Weather Sales and Services, Inc',NULL,NULL,NULL),(54,'2016-09-09','system',NULL,NULL,'Adam Matthew Digital Ltd',NULL,NULL,NULL),(55,'2016-09-09','system',NULL,NULL,'Akademiai Kiado',NULL,NULL,NULL),(56,'2016-09-09','system',NULL,NULL,'World Trade Press',NULL,NULL,NULL),(57,'2016-09-09','system',NULL,NULL,'World Scientific',NULL,NULL,NULL),(58,'2016-09-09','system',NULL,NULL,'Walter de Gruyter',NULL,NULL,NULL),(59,'2016-09-09','system',NULL,NULL,'Cambridge University Press',NULL,NULL,NULL),(60,'2016-09-09','system',NULL,NULL,'GeoScienceWorld',NULL,NULL,NULL),(61,'2016-09-09','system',NULL,NULL,'IEEE',NULL,NULL,NULL),(62,'2016-09-09','system',NULL,NULL,'Yankelovich Inc',NULL,NULL,NULL),(63,'2016-09-09','system',NULL,NULL,'Nature Publishing Group',NULL,NULL,NULL),(64,'2016-09-09','system',NULL,NULL,'Verlag der Zeitschrift fur Naturforschung ',NULL,NULL,NULL),(65,'2016-09-09','system',NULL,NULL,'White Horse Press',NULL,NULL,NULL),(66,'2016-09-09','system',NULL,NULL,'Verlag C.H. Beck',NULL,NULL,NULL),(67,'2016-09-09','system',NULL,NULL,'Vault, Inc',NULL,NULL,NULL),(68,'2016-09-09','system',NULL,NULL,'Value Line, Inc',NULL,NULL,NULL),(69,'2016-09-09','system',NULL,NULL,'Vanderbilt University',NULL,NULL,NULL),(70,'2016-09-09','system',NULL,NULL,'Uniworld Business Publications, Inc',NULL,NULL,NULL),(71,'2016-09-09','system',NULL,NULL,'Universum USA',NULL,NULL,NULL),(72,'2016-09-09','system',NULL,NULL,'University of Wisconsin Press',NULL,NULL,NULL),(73,'2016-09-09','system',NULL,NULL,'University of Virginia Press',NULL,NULL,NULL),(74,'2016-09-09','system',NULL,NULL,'University of Toronto Press Inc',NULL,NULL,NULL),(75,'2016-09-09','system',NULL,NULL,'University of Toronto',NULL,NULL,NULL),(76,'2016-09-09','system',NULL,NULL,'University of Pittsburgh',NULL,NULL,NULL),(77,'2016-09-09','system',NULL,NULL,'University of Illinois Press',NULL,NULL,NULL),(78,'2016-09-09','system',NULL,NULL,'University of Chicago Press',NULL,NULL,NULL),(79,'2016-09-09','system',NULL,NULL,'University of Barcelona',NULL,NULL,NULL),(80,'2016-09-09','system',NULL,NULL,'UCLA Chicano Studies Research Center Press',NULL,NULL,NULL),(81,'2016-09-09','system',NULL,NULL,'Transportation Research Board',NULL,NULL,NULL),(82,'2016-09-09','system',NULL,NULL,'Trans Tech Publications',NULL,NULL,NULL),(83,'2016-09-09','system',NULL,NULL,'Thomas Telford Ltd',NULL,NULL,NULL),(84,'2016-09-09','system',NULL,NULL,'Thesaurus Linguae Graecae',NULL,NULL,NULL),(85,'2016-09-09','system',NULL,NULL,'Tetrad Computer Applications Inc',NULL,NULL,NULL),(86,'2016-09-09','system',NULL,NULL,'Swank Motion Pictures, Inc',NULL,NULL,NULL),(87,'2016-09-09','system',NULL,NULL,'Standard and Poors',NULL,NULL,NULL),(88,'2016-09-09','system',NULL,NULL,'SPIE',NULL,NULL,NULL),(89,'2016-09-09','system',NULL,NULL,'European Society of Endocrinology',NULL,NULL,NULL),(90,'2016-09-09','system',NULL,NULL,'Society of Environmental Toxicology and Chemistry',NULL,NULL,NULL),(91,'2016-09-09','system',NULL,NULL,'Society of Antiquaries of Scotland',NULL,NULL,NULL),(92,'2016-09-09','system',NULL,NULL,'Society for Reproduction and Fertility',NULL,NULL,NULL),(93,'2016-09-09','system',NULL,NULL,'Society for Neuroscience',NULL,NULL,NULL),(94,'2016-09-09','system',NULL,NULL,'Society for Leukocyte Biology',NULL,NULL,NULL),(95,'2016-09-09','system',NULL,NULL,'Society for General Microbiology',NULL,NULL,NULL),(96,'2016-09-09','system',NULL,NULL,'Society for Experimental Biology and Medicine',NULL,NULL,NULL),(97,'2016-09-09','system',NULL,NULL,'Society for Endocrinology',NULL,NULL,NULL),(98,'2016-09-09','system',NULL,NULL,'Societe Mathematique de France',NULL,NULL,NULL),(99,'2016-09-09','system',NULL,NULL,'Social Explorer',NULL,NULL,NULL),(404,'2016-09-09','system',NULL,NULL,'SETAC',NULL,NULL,NULL),(101,'2016-09-09','system',NULL,NULL,'Swiss Chemical Society',NULL,NULL,NULL),(102,'2016-09-09','system',NULL,NULL,'Scholarly Digital Editions',NULL,NULL,NULL),(103,'2016-09-09','system',NULL,NULL,'Royal Society of London',NULL,NULL,NULL),(104,'2016-09-09','system',NULL,NULL,'Royal Society of Chemistry',NULL,NULL,NULL),(105,'2016-09-09','system',NULL,NULL,'Roper Center for Public Opinion Research',NULL,NULL,NULL),(106,'2016-09-09','system',NULL,NULL,'Rockefeller University Press',NULL,NULL,NULL),(107,'2016-09-09','system',NULL,NULL,'Rivista di Studi italiani',NULL,NULL,NULL),(108,'2016-09-09','system',NULL,NULL,'Reuters Loan Pricing Corporation',NULL,NULL,NULL),(109,'2016-09-09','system',NULL,NULL,'Religious and Theological Abstracts, Inc',NULL,NULL,NULL),(110,'2016-09-09','system',NULL,NULL,'Psychoanalytic Electronic Publishing Inc',NULL,NULL,NULL),(111,'2016-09-09','system',NULL,NULL,'Cornell University Library',NULL,NULL,NULL),(112,'2016-09-09','system',NULL,NULL,'Preservation Technologies LP',NULL,NULL,NULL),(113,'2016-09-09','system',NULL,NULL,'Portland Press Limited',NULL,NULL,NULL),(114,'2016-09-09','system',NULL,NULL,'ITHAKA',NULL,NULL,NULL),(115,'2016-09-09','system',NULL,NULL,'Philosophy Documentation Center',NULL,NULL,NULL),(116,'2016-09-09','system',NULL,NULL,'Peeters Publishers',NULL,NULL,NULL),(117,'2016-09-09','system',NULL,NULL,'Paratext',NULL,NULL,NULL),(118,'2016-09-09','system',NULL,NULL,'Mathematical Sciences Publishers',NULL,NULL,NULL),(119,'2016-09-09','system',NULL,NULL,'Oxford Centre of Hebrew and Jewish Studies',NULL,NULL,NULL),(120,'2016-09-09','system',NULL,NULL,'NewsBank, Inc',NULL,NULL,NULL),(121,'2016-09-09','system',NULL,NULL,'Massachusetts Medical Society',NULL,NULL,NULL),(122,'2016-09-09','system',NULL,NULL,'Naxos of America, Inc.',NULL,NULL,NULL),(123,'2016-09-09','system',NULL,NULL,'National Research Council of Canada',NULL,NULL,NULL),(124,'2016-09-09','system',NULL,NULL,'National Gallery Company Ltd',NULL,NULL,NULL),(125,'2016-09-09','system',NULL,NULL,'National Academy of Sciences',NULL,NULL,NULL),(126,'2016-09-09','system',NULL,NULL,'Mintel International Group Limited',NULL,NULL,NULL),(127,'2016-09-09','system',NULL,NULL,'Metropolitan Opera',NULL,NULL,NULL),(128,'2016-09-09','system',NULL,NULL,'M.E. Sharpe, Inc',NULL,NULL,NULL),(129,'2016-09-09','system',NULL,NULL,'Mergent, Inc',NULL,NULL,NULL),(130,'2016-09-09','system',NULL,NULL,'Mediamark Research and Intelligence, LLC',NULL,NULL,NULL),(131,'2016-09-09','system',NULL,NULL,'Mary Ann Liebert, Inc',NULL,NULL,NULL),(132,'2016-09-09','system',NULL,NULL,'MIT Press',NULL,NULL,NULL),(133,'2016-09-09','system',NULL,NULL,'MarketResearch.com, Inc',NULL,NULL,NULL),(134,'2016-09-09','system',NULL,NULL,'Marine Biological Laboratory',NULL,NULL,NULL),(135,'2016-09-09','system',NULL,NULL,'W.S. Maney and Son Ltd',NULL,NULL,NULL),(136,'2016-09-09','system',NULL,NULL,'Manchester University Press',NULL,NULL,NULL),(137,'2016-09-09','system',NULL,NULL,'Lord Music Reference Inc',NULL,NULL,NULL),(138,'2016-09-09','system',NULL,NULL,'Liverpool University Press',NULL,NULL,NULL),(139,'2016-09-09','system',NULL,NULL,'Seminario Matematico of the University of Padua',NULL,NULL,NULL),(140,'2016-09-09','system',NULL,NULL,'Library of Congress, Cataloging Distribution Service',NULL,NULL,NULL),(141,'2016-09-09','system',NULL,NULL,'LexisNexis',NULL,NULL,NULL),(142,'2016-09-09','system',NULL,NULL,'Corporacion Latinobarometro',NULL,NULL,NULL),(143,'2016-09-09','system',NULL,NULL,'Landes Bioscience',NULL,NULL,NULL),(144,'2016-09-09','system',NULL,NULL,'Keesings Worldwide, LLC',NULL,NULL,NULL),(145,'2016-09-09','system',NULL,NULL,'Karger',NULL,NULL,NULL),(146,'2016-09-09','system',NULL,NULL,'John Benjamins Publishing Company',NULL,NULL,NULL),(147,'2016-09-09','system',NULL,NULL,'Irish Newspaper Archives Ltd',NULL,NULL,NULL),(148,'2016-09-09','system',NULL,NULL,'IPA Source, LLC',NULL,NULL,NULL),(149,'2016-09-09','system',NULL,NULL,'International Press',NULL,NULL,NULL),(150,'2016-09-09','system',NULL,NULL,'Intelligence Research Limited',NULL,NULL,NULL),(151,'2016-09-09','system',NULL,NULL,'Intellect',NULL,NULL,NULL),(152,'2016-09-09','system',NULL,NULL,'InteLex',NULL,NULL,NULL),(153,'2016-09-09','system',NULL,NULL,'Institute of Mathematics of the Polish Academy of Sciences',NULL,NULL,NULL),(154,'2016-09-09','system',NULL,NULL,'Ingentaconnect',NULL,NULL,NULL),(155,'2016-09-09','system',NULL,NULL,'INFORMS',NULL,NULL,NULL),(156,'2016-09-09','system',NULL,NULL,'Information Resources, Inc',NULL,NULL,NULL),(157,'2016-09-09','system',NULL,NULL,'Indiana University Mathematics Journal',NULL,NULL,NULL),(158,'2016-09-09','system',NULL,NULL,'Incisive Media Ltd',NULL,NULL,NULL),(159,'2016-09-09','system',NULL,NULL,'IGI Global ',NULL,NULL,NULL),(160,'2016-09-09','system',NULL,NULL,'IBISWorld USA',NULL,NULL,NULL),(161,'2016-09-09','system',NULL,NULL,'H.W. Wilson Company',NULL,NULL,NULL),(162,'2016-09-09','system',NULL,NULL,'University of Houston Department of Mathematics',NULL,NULL,NULL),(163,'2016-09-09','system',NULL,NULL,'Histochemical Society',NULL,NULL,NULL),(164,'2016-09-09','system',NULL,NULL,'Morningstar Inc.',NULL,NULL,NULL),(165,'2016-09-09','system',NULL,NULL,'Paradigm Publishers',NULL,NULL,NULL),(166,'2016-09-09','system',NULL,NULL,'HighWire Press',NULL,NULL,NULL),(167,'2016-09-09','system',NULL,NULL,'Heldref Publications',NULL,NULL,NULL),(168,'2016-09-09','system',NULL,NULL,'Haworth Press',NULL,NULL,NULL),(417,'2016-09-09','system',NULL,NULL,'Thomson Legal',NULL,NULL,NULL),(170,'2016-09-09','system',NULL,NULL,'IOS Press',NULL,NULL,NULL),(171,'2016-09-09','system',NULL,NULL,'Agricultural Institute of Canada',NULL,NULL,NULL),(172,'2016-09-09','system',NULL,NULL,'Allen Press',NULL,NULL,NULL),(173,'2016-09-09','system',NULL,NULL,'H1 Base, Inc',NULL,NULL,NULL),(175,'2016-09-09','system',NULL,NULL,'Global Science Press',NULL,NULL,NULL),(176,'2016-09-09','system',NULL,NULL,'Geographic Research, Inc',NULL,NULL,NULL),(177,'2016-09-09','system',NULL,NULL,'Genetics Society of America',NULL,NULL,NULL),(178,'2016-09-09','system',NULL,NULL,'Franz Steiner Verlag',NULL,NULL,NULL),(179,'2016-09-09','system',NULL,NULL,'Forrester Research, Inc',NULL,NULL,NULL),(180,'2016-09-09','system',NULL,NULL,'Federation of American Societies for Experimental Biology',NULL,NULL,NULL),(181,'2016-09-09','system',NULL,NULL,'Faulkner Information Services',NULL,NULL,NULL),(182,'2016-09-09','system',NULL,NULL,'ExLibris',NULL,NULL,NULL),(183,'2016-09-09','system',NULL,NULL,'Brill',NULL,NULL,NULL),(184,'2016-09-09','system',NULL,NULL,'Evolutionary Ecology Ltd',NULL,NULL,NULL),(185,'2016-09-09','system',NULL,NULL,'European Mathematical Society Publishing House',NULL,NULL,NULL),(186,'2016-09-09','system',NULL,NULL,'New York Review of Books',NULL,NULL,NULL),(187,'2016-09-09','system',NULL,NULL,'Dunstans Publishing Ltd',NULL,NULL,NULL),(188,'2016-09-09','system',NULL,NULL,'Equinox Publishing Ltd',NULL,NULL,NULL),(189,'2016-09-09','system',NULL,NULL,'Entomological Society of Canada',NULL,NULL,NULL),(190,'2016-09-09','system',NULL,NULL,'American Association of Immunologists, Inc.',NULL,NULL,NULL),(191,'2016-09-09','system',NULL,NULL,'Endocrine Society',NULL,NULL,NULL),(192,'2016-09-09','system',NULL,NULL,'EDP Sciences',NULL,NULL,NULL),(193,'2016-09-09','system',NULL,NULL,'Edinburgh University Press',NULL,NULL,NULL),(194,'2016-09-09','system',NULL,NULL,'Ecological Society of America',NULL,NULL,NULL),(195,'2016-09-09','system',NULL,NULL,'East View Information Services',NULL,NULL,NULL),(196,'2016-09-09','system',NULL,NULL,'Dun and Bradstreet Inc',NULL,NULL,NULL),(197,'2016-09-09','system',NULL,NULL,'Duke University Press',NULL,NULL,NULL),(198,'2016-09-09','system',NULL,NULL,'Digital Distributed Community Archive',NULL,NULL,NULL),(199,'2016-09-09','system',NULL,NULL,'Albert C. Muller',NULL,NULL,NULL),(200,'2016-09-09','system',NULL,NULL,'Dialogue Foundation',NULL,NULL,NULL),(201,'2016-09-09','system',NULL,NULL,'Dialog',NULL,NULL,NULL),(202,'2016-09-09','system',NULL,NULL,'Current History, Inc',NULL,NULL,NULL),(203,'2016-09-09','system',NULL,NULL,'CSIRO Publishing',NULL,NULL,NULL),(204,'2016-09-09','system',NULL,NULL,'CQ Press',NULL,NULL,NULL),(205,'2016-09-09','system',NULL,NULL,'Japan Focus',NULL,NULL,NULL),(206,'2016-09-09','system',NULL,NULL,'Carbon Disclosure Project',NULL,NULL,NULL),(207,'2016-09-09','system',NULL,NULL,'University of Buckingham Press',NULL,NULL,NULL),(208,'2016-09-09','system',NULL,NULL,'Boopsie, INC.',NULL,NULL,NULL),(209,'2016-09-09','system',NULL,NULL,'Company of Biologists Ltd',NULL,NULL,NULL),(210,'2016-09-09','system',NULL,NULL,'Chronicle of Higher Education',NULL,NULL,NULL),(211,'2016-09-09','system',NULL,NULL,'CCH Incorporated',NULL,NULL,NULL),(212,'2016-09-09','system',NULL,NULL,'CareerShift LLC',NULL,NULL,NULL),(213,'2016-09-09','system',NULL,NULL,'Canadian Mathematical Society',NULL,NULL,NULL),(214,'2016-09-09','system',NULL,NULL,'Cambridge Crystallographic Data Centre',NULL,NULL,NULL),(215,'2016-09-09','system',NULL,NULL,'CABI Publishing',NULL,NULL,NULL),(216,'2016-09-09','system',NULL,NULL,'Business Monitor International',NULL,NULL,NULL),(217,'2016-09-09','system',NULL,NULL,'Bureau of National Affairs, Inc',NULL,NULL,NULL),(218,'2016-09-09','system',NULL,NULL,'Bulletin of the Atomic Scientists',NULL,NULL,NULL),(219,'2016-09-09','system',NULL,NULL,'Brepols Publishers',NULL,NULL,NULL),(221,'2016-09-09','system',NULL,NULL,'Botanical Society of America',NULL,NULL,NULL),(222,'2016-09-09','system',NULL,NULL,'BMJ Publishing Group Limited',NULL,NULL,NULL),(223,'2016-09-09','system',NULL,NULL,'BioMed Central',NULL,NULL,NULL),(224,'2016-09-09','system',NULL,NULL,'Berkeley Electronic Press',NULL,NULL,NULL),(225,'2016-09-09','system',NULL,NULL,'Berghahn Books',NULL,NULL,NULL),(226,'2016-09-09','system',NULL,NULL,'Berg Publishers',NULL,NULL,NULL),(227,'2016-09-09','system',NULL,NULL,'Belser Wissenschaftlicher Dienst Ltd',NULL,NULL,NULL),(228,'2016-09-09','system',NULL,NULL,'Beilstein Information Systems, Inc',NULL,NULL,NULL),(229,'2016-09-09','system',NULL,NULL,'Barkhuis Publishing',NULL,NULL,NULL),(230,'2016-09-09','system',NULL,NULL,'Augustine Institute',NULL,NULL,NULL),(231,'2016-09-09','system',NULL,NULL,'Asempa Limited',NULL,NULL,NULL),(232,'2016-09-09','system',NULL,NULL,'ARTstor Inc',NULL,NULL,NULL),(233,'2016-09-09','system',NULL,NULL,'Applied Probability Trust',NULL,NULL,NULL),(234,'2016-09-09','system',NULL,NULL,'Antiquity Publications Limited',NULL,NULL,NULL),(235,'2016-09-09','system',NULL,NULL,'Ammons Scientific Limited',NULL,NULL,NULL),(236,'2016-09-09','system',NULL,NULL,'American Statistical Association',NULL,NULL,NULL),(237,'2016-09-09','system',NULL,NULL,'American Society of Tropical Medicine and Hygiene',NULL,NULL,NULL),(238,'2016-09-09','system',NULL,NULL,'American Society of Plant Biologists',NULL,NULL,NULL),(239,'2016-09-09','system',NULL,NULL,'Teachers College Record',NULL,NULL,NULL),(240,'2016-09-09','system',NULL,NULL,'American Society of Agronomy',NULL,NULL,NULL),(241,'2016-09-09','system',NULL,NULL,'American Society for Nutrition',NULL,NULL,NULL),(242,'2016-09-09','system',NULL,NULL,'American Society for Horticultural Science',NULL,NULL,NULL),(243,'2016-09-09','system',NULL,NULL,'American Society for Clinical Investigation',NULL,NULL,NULL),(244,'2016-09-09','system',NULL,NULL,'American Society for Cell Biology',NULL,NULL,NULL),(245,'2016-09-09','system',NULL,NULL,'American Psychiatric Publishing',NULL,NULL,NULL),(246,'2016-09-09','system',NULL,NULL,'American Phytopathological Society',NULL,NULL,NULL),(247,'2016-09-09','system',NULL,NULL,'American Physiological Society',NULL,NULL,NULL),(248,'2016-09-09','system',NULL,NULL,'Encyclopaedia Britannica Online',NULL,NULL,NULL),(249,'2016-09-09','system',NULL,NULL,'Agricultural History Society',NULL,NULL,NULL),(250,'2016-09-09','system',NULL,NULL,'Begell House, Inc',NULL,NULL,NULL),(251,'2016-09-09','system',NULL,NULL,'Hans Zell Publishing',NULL,NULL,NULL),(252,'2016-09-09','system',NULL,NULL,'Alliance for Children and Families',NULL,NULL,NULL),(253,'2016-09-09','system',NULL,NULL,'Robert Blakemore',NULL,NULL,NULL),(254,'2016-09-09','system',NULL,NULL,'IVES Group, Inc',NULL,NULL,NULL),(255,'2016-09-09','system',NULL,NULL,'Massachusetts Institute of Technology',NULL,NULL,NULL),(256,'2016-09-09','system',NULL,NULL,'Marquis Who\'s Who LLC',NULL,NULL,NULL),(257,'2016-09-09','system',NULL,NULL,'Atypon Systems Inc',NULL,NULL,NULL),(258,'2016-09-09','system',NULL,NULL,'Worldwatch Institute',NULL,NULL,NULL),(259,'2016-09-09','system',NULL,NULL,'Thomson Financial',NULL,NULL,NULL),(260,'2016-09-09','system',NULL,NULL,'Digital Heritage Publishing Limited',NULL,NULL,NULL),(261,'2016-09-09','system',NULL,NULL,'U.S. Department of Commerce',NULL,NULL,NULL),(262,'2016-09-09','system',NULL,NULL,'Lipper Inc',NULL,NULL,NULL),(263,'2016-09-09','system',NULL,NULL,'Chiniquy Collection',NULL,NULL,NULL),(264,'2016-09-09','system',NULL,NULL,'OCLC',NULL,NULL,NULL),(265,'2016-09-09','system',NULL,NULL,'Consumer Electronics Association',NULL,NULL,NULL),(267,'2016-09-09','system',NULL,NULL,'Institutional Shareholder Services Inc',NULL,NULL,NULL),(268,'2016-09-09','system',NULL,NULL,'KLD Research and Analytics Inc',NULL,NULL,NULL),(269,'2016-09-09','system',NULL,NULL,'BIGresearch LLC',NULL,NULL,NULL),(270,'2016-09-09','system',NULL,NULL,'Cambridge Scientific Abstracts',NULL,NULL,NULL),(271,'2016-09-09','system',NULL,NULL,'American Institute of Certified Public Accountants',NULL,NULL,NULL),(272,'2016-09-09','system',NULL,NULL,'Terra Scientific Publishing Company',NULL,NULL,NULL),(273,'2016-09-09','system',NULL,NULL,'American Counseling Association',NULL,NULL,NULL),(274,'2016-09-09','system',NULL,NULL,'Army Times Publishing Company',NULL,NULL,NULL),(275,'2016-09-09','system',NULL,NULL,'Librairie Droz',NULL,NULL,NULL),(276,'2016-09-09','system',NULL,NULL,'American Academy of Religion',NULL,NULL,NULL),(277,'2016-09-09','system',NULL,NULL,'Boyd Printing',NULL,NULL,NULL),(278,'2016-09-09','system',NULL,NULL,'Canadian Association of African Studies',NULL,NULL,NULL),(279,'2016-09-09','system',NULL,NULL,'Experian Marketing Solutions, Inc.',NULL,NULL,NULL),(280,'2016-09-09','system',NULL,NULL,'Centro de Investigaciones Sociologicas',NULL,NULL,NULL),(281,'2016-09-09','system',NULL,NULL,'Chorus America',NULL,NULL,NULL),(282,'2016-09-09','system',NULL,NULL,'College Art Association',NULL,NULL,NULL),(283,'2016-09-09','system',NULL,NULL,'Human Kinetics Inc.',NULL,NULL,NULL),(288,'2016-09-09','system',NULL,NULL,'NERL',NULL,NULL,NULL),(293,'2016-09-09','system',NULL,NULL,'Colegio de Mexico',NULL,NULL,NULL),(294,'2016-09-09','system',NULL,NULL,'University of Iowa',NULL,NULL,NULL),(295,'2016-09-09','system',NULL,NULL,'Academy of the Hebrew Language',NULL,NULL,NULL),(296,'2016-09-09','system',NULL,NULL,'FamilyLink.com, Inc.',NULL,NULL,NULL),(297,'2016-09-09','system',NULL,NULL,'SISMEL - Edizioni del Galluzzo',NULL,NULL,NULL),(301,'2016-09-09','system',NULL,NULL,'Informaworld',NULL,NULL,NULL),(302,'2016-09-09','system',NULL,NULL,'ScienceDirect',NULL,NULL,NULL),(304,'2016-09-09','system',NULL,NULL,'China Data Center',NULL,NULL,NULL),(305,'2016-09-09','system',NULL,NULL,'Association for Computing Machinery',NULL,NULL,NULL),(306,'2016-09-09','system',NULL,NULL,'American Chemical Society',NULL,NULL,NULL),(307,'2016-09-09','system',NULL,NULL,'Design Research Publications',NULL,NULL,NULL),(308,'2016-09-09','system',NULL,NULL,'ABC-CLIO',NULL,NULL,NULL),(311,'2016-09-09','system',NULL,NULL,'American Association on Intellectual and Developmental Disabilities ',NULL,NULL,NULL),(310,'2016-09-09','system',NULL,NULL,'American Antiquarian Society',NULL,NULL,NULL),(312,'2016-09-09','system',NULL,NULL,'American Society for Microbiology',NULL,NULL,NULL),(314,'2016-09-09','system',NULL,NULL,'American Society of Mechanical Engineers',NULL,NULL,NULL),(315,'2016-09-09','system',NULL,NULL,'Now Publishers, Inc.',NULL,NULL,NULL),(316,'2016-09-09','system',NULL,NULL,'Cabell Publishing Company, Inc.',NULL,NULL,NULL),(317,'2016-09-09','system',NULL,NULL,'Center for Research Libraries',NULL,NULL,NULL),(444,'2016-09-09','system',NULL,NULL,'Cold North Wind Inc',NULL,NULL,NULL),(321,'2016-09-09','system',NULL,NULL,'Erudit ',NULL,NULL,NULL),(322,'2016-09-09','system',NULL,NULL,'American Institute of Mathematical Sciences',NULL,NULL,NULL),(324,'2016-09-09','system',NULL,NULL,'American Sociological Association',NULL,NULL,NULL),(325,'2016-09-09','system',NULL,NULL,'Archaeological Institute of America',NULL,NULL,NULL),(326,'2016-09-09','system',NULL,NULL,'Bertrand Russell Research Centre',NULL,NULL,NULL),(328,'2016-09-09','system',NULL,NULL,'Cork University Press',NULL,NULL,NULL),(329,'2016-09-09','system',NULL,NULL,'College Publishing',NULL,NULL,NULL),(330,'2016-09-09','system',NULL,NULL,'Council for Learning Disabilities',NULL,NULL,NULL),(331,'2016-09-09','system',NULL,NULL,'International Society on Hypertension in Blacks (ISHIB)',NULL,NULL,NULL),(332,'2016-09-09','system',NULL,NULL,'Firenze University Press',NULL,NULL,NULL),(333,'2016-09-09','system',NULL,NULL,'History of Earth Sciences Society',NULL,NULL,NULL),(334,'2016-09-09','system',NULL,NULL,'History Today Ltd.',NULL,NULL,NULL),(335,'2016-09-09','system',NULL,NULL,'Journal of Music',NULL,NULL,NULL),(336,'2016-09-09','system',NULL,NULL,'University of Nebraska at Omaha',NULL,NULL,NULL),(337,'2016-09-09','system',NULL,NULL,'Journal of Indo-European Studies',NULL,NULL,NULL),(338,'2016-09-09','system',NULL,NULL,'Library Binding Institute',NULL,NULL,NULL),(339,'2016-09-09','system',NULL,NULL,'McFarland & Co. Inc.',NULL,NULL,NULL),(340,'2016-09-09','system',NULL,NULL,'Lyrasis',NULL,NULL,NULL),(341,'2016-09-09','system',NULL,NULL,'Amigos Library Services',NULL,NULL,NULL),(343,'2016-09-09','system',NULL,NULL,'Fabrizio Serra Editore',NULL,NULL,NULL),(344,'2016-09-09','system',NULL,NULL,'Aux Amateurs',NULL,NULL,NULL),(346,'2016-09-09','system',NULL,NULL,'National Affairs, Inc',NULL,NULL,NULL),(357,'2016-09-09','system',NULL,NULL,'Society of Chemical Industry',NULL,NULL,NULL),(347,'2016-09-09','system',NULL,NULL,'New Criterion',NULL,NULL,NULL),(348,'2016-09-09','system',NULL,NULL,'Casa Editrice Leo S. Olschki s.r.l.',NULL,NULL,NULL),(349,'2016-09-09','system',NULL,NULL,'Rhodes University, Department of Philosophy',NULL,NULL,NULL),(350,'2016-09-09','system',NULL,NULL,'Rocky Mountain Mathematics Consortium',NULL,NULL,NULL),(352,'2016-09-09','system',NULL,NULL,'Royal Irish Academy',NULL,NULL,NULL),(353,'2016-09-09','system',NULL,NULL,'Chadwyck-Healey',NULL,NULL,NULL),(354,'2016-09-09','system',NULL,NULL,'CSA illumina',NULL,NULL,NULL),(355,'2016-09-09','system',NULL,NULL,'New School for Social Research',NULL,NULL,NULL),(356,'2016-09-09','system',NULL,NULL,'Society of Biblical Literature',NULL,NULL,NULL),(358,'2016-09-09','system',NULL,NULL,'Stazione Zoologica Anton Dohrn',NULL,NULL,NULL),(359,'2016-09-09','system',NULL,NULL,'BioScientifica Ltd.',NULL,NULL,NULL),(360,'2016-09-09','system',NULL,NULL,'CASALINI LIBRI',NULL,NULL,NULL),(361,'2016-09-09','system',NULL,NULL,'Institute of Organic Chemistry',NULL,NULL,NULL),(362,'2016-09-09','system',NULL,NULL,'Columbia International Affairs Online ',NULL,NULL,NULL),(363,'2016-09-09','system',NULL,NULL,'Corporation for National Research Initiatives ',NULL,NULL,NULL),(364,'2016-09-09','system',NULL,NULL,'Tilgher-Genova',NULL,NULL,NULL),(365,'2016-09-09','system',NULL,NULL,'Emerald Group Publishing Limited',NULL,NULL,NULL),(366,'2016-09-09','system',NULL,NULL,'Geological Society of America',NULL,NULL,NULL),(367,'2016-09-09','system',NULL,NULL,'Institute of Mathematical Statistics',NULL,NULL,NULL),(368,'2016-09-09','system',NULL,NULL,'Institute of Pure and Applied Physics',NULL,NULL,NULL),(369,'2016-09-09','system',NULL,NULL,'JSTAGE',NULL,NULL,NULL),(370,'2016-09-09','system',NULL,NULL,'Metapress',NULL,NULL,NULL),(371,'2016-09-09','system',NULL,NULL,'Modern Language Association',NULL,NULL,NULL),(372,'2016-09-09','system',NULL,NULL,'Optical Society of America',NULL,NULL,NULL),(373,'2016-09-09','system',NULL,NULL,'University of British Columbia',NULL,NULL,NULL),(374,'2016-09-09','system',NULL,NULL,'University of New Mexico',NULL,NULL,NULL),(375,'2016-09-09','system',NULL,NULL,'Vandenhoeck & Ruprecht',NULL,NULL,NULL),(376,'2016-09-09','system',NULL,NULL,'Verlag Mohr Siebeck GmbH & Co. KG',NULL,NULL,NULL),(377,'2016-09-09','system',NULL,NULL,'Palgrave Macmillan',NULL,NULL,NULL),(378,'2016-09-09','system',NULL,NULL,'Vittorio Klostermann',NULL,NULL,NULL),(379,'2016-09-09','system',NULL,NULL,'Project Euclid',NULL,NULL,NULL),(380,'2016-09-09','system',NULL,NULL,'Psychonomic Society ',NULL,NULL,NULL),(411,'2016-09-09','system',NULL,NULL,'Cengage Learning',NULL,NULL,NULL),(382,'2016-09-09','system',NULL,NULL,'Infotrieve',NULL,NULL,NULL),(383,'2016-09-09','system',NULL,NULL,'Society of Automotive Engineers',NULL,NULL,NULL),(384,'2016-09-09','system',NULL,NULL,'Turpion Publications',NULL,NULL,NULL),(426,'2016-09-09','system',NULL,NULL,'Midwest Collaborative for Library Services',NULL,NULL,NULL),(386,'2016-09-09','system',NULL,NULL,'Lawrence Erlbaum Associates',NULL,NULL,NULL),(387,'2016-09-09','system',NULL,NULL,'Alphagraphics',NULL,NULL,NULL),(388,'2016-09-09','system',NULL,NULL,'Bellerophon Publications, Inc.',NULL,NULL,NULL),(389,'2016-09-09','system',NULL,NULL,'Boydell & Brewer Inc.',NULL,NULL,NULL),(390,'2016-09-09','system',NULL,NULL,'Carcanet Press',NULL,NULL,NULL),(391,'2016-09-09','system',NULL,NULL,'Feminist Studies',NULL,NULL,NULL),(393,'2016-09-09','system',NULL,NULL,'Dustbooks',NULL,NULL,NULL),(394,'2016-09-09','system',NULL,NULL,'Society for Applied Anthropology ',NULL,NULL,NULL),(395,'2016-09-09','system',NULL,NULL,'United Nations Publications',NULL,NULL,NULL),(396,'2016-09-09','system',NULL,NULL,'Wharton Research Data Services',NULL,NULL,NULL),(398,'2016-09-09','system',NULL,NULL,'Human Development',NULL,NULL,NULL),(399,'2016-09-09','system',NULL,NULL,'infoUSA Marketing, Inc.',NULL,NULL,NULL),(400,'2016-09-09','system',NULL,NULL,'Bowker',NULL,NULL,NULL),(402,'2016-09-09','system',NULL,NULL,'Brown University',NULL,NULL,NULL),(401,'2016-09-09','system',NULL,NULL,'Women Writers Project',NULL,NULL,NULL),(445,'2016-09-09','system',NULL,NULL,'Coutts',NULL,NULL,NULL),(446,'2016-09-09','system',NULL,NULL,'Numara Software, Inc.',NULL,NULL,NULL),(447,'2016-09-09','system',NULL,NULL,'Trinity College Library Dublin',NULL,NULL,NULL),(405,'2016-09-09','system',NULL,NULL,'Oldenbourg Wissenschaftsverlag ',NULL,NULL,NULL),(406,'2016-09-09','system',NULL,NULL,'Dow Jones',NULL,NULL,NULL),(412,'2016-09-09','system',NULL,NULL,'Financial Information Inc. (FII)',NULL,NULL,NULL),(408,'2016-09-09','system',NULL,NULL,'Jackson Publishing and Distribution',NULL,NULL,NULL),(409,'2016-09-09','system',NULL,NULL,'Elsevier Engineering Information, Inc. ',NULL,NULL,NULL),(410,'2016-09-09','system',NULL,NULL,'Eneclann Ltd.',NULL,NULL,NULL),(413,'2016-09-09','system',NULL,NULL,'UCLA Latin American Institute',NULL,NULL,NULL),(414,'2016-09-09','system',NULL,NULL,'Harmonie Park Press ',NULL,NULL,NULL),(415,'2016-09-09','system',NULL,NULL,'Harrassowitz',NULL,NULL,NULL),(416,'2016-09-09','system',NULL,NULL,'Thomson Reuters',NULL,NULL,NULL),(418,'2016-09-09','system',NULL,NULL,'Human Relations Area Files, Inc. ',NULL,NULL,NULL),(432,'2016-09-09','system',NULL,NULL,'Capital IQ',NULL,NULL,NULL),(419,'2016-09-09','system',NULL,NULL,'Society for Ethnomusicology',NULL,NULL,NULL),(420,'2016-09-09','system',NULL,NULL,'MSCI RiskMetrics',NULL,NULL,NULL),(421,'2016-09-09','system',NULL,NULL,'Rapid Multimedia',NULL,NULL,NULL),(422,'2016-09-09','system',NULL,NULL,'MSCI Inc',NULL,NULL,NULL),(423,'2016-09-09','system',NULL,NULL,'New England Journal of Medicine',NULL,NULL,NULL),(424,'2016-09-09','system',NULL,NULL,'NetLibrary',NULL,NULL,NULL),(425,'2016-09-09','system',NULL,NULL,'CARMA',NULL,NULL,NULL),(427,'2016-09-09','system',NULL,NULL,'Public Library of Science',NULL,NULL,NULL),(428,'2016-09-09','system',NULL,NULL,'Social Science Electronic Publishing',NULL,NULL,NULL),(429,'2016-09-09','system',NULL,NULL,'United Nations Industrial Develoipment Organization',NULL,NULL,NULL),(430,'2016-09-09','system',NULL,NULL,'University of Michigan Press',NULL,NULL,NULL),(431,'2016-09-09','system',NULL,NULL,'ORS Publishing, Inc.',NULL,NULL,NULL),(433,'2016-09-09','system',NULL,NULL,'McGraw-Hill',NULL,NULL,NULL),(434,'2016-09-09','system',NULL,NULL,'Biblical Archaeology Society',NULL,NULL,NULL),(435,'2016-09-09','system',NULL,NULL,'GeoLytics, Inc.',NULL,NULL,NULL),(436,'2016-09-09','system',NULL,NULL,'JoVE ',NULL,NULL,NULL),(437,'2016-09-09','system',NULL,NULL,'ICEsoft Technologies, Inc.',NULL,NULL,NULL),(438,'2016-09-09','system',NULL,NULL,'Films Media Group',NULL,NULL,NULL),(439,'2016-09-09','system',NULL,NULL,'Films on Demand',NULL,NULL,NULL),(440,'2016-09-09','system',NULL,NULL,'Connect Journals',NULL,NULL,NULL),(441,'2016-09-09','system',NULL,NULL,'Scuola Normale Superiore',NULL,NULL,NULL),(442,'2016-09-09','system',NULL,NULL,'Wolters Kluwer',NULL,NULL,NULL),(448,'2016-09-09','system',NULL,NULL,'Pier Professional',NULL,NULL,NULL),(449,'2016-09-09','system',NULL,NULL,'ABC News',NULL,NULL,NULL),(450,'2016-09-09','system',NULL,NULL,'University of Aberdeen ',NULL,NULL,NULL),(451,'2016-09-09','system',NULL,NULL,'BullFrog Films, Inc.',NULL,NULL,NULL),(453,'2016-09-09','system',NULL,NULL,'FirstSearch',NULL,NULL,NULL),(455,'2016-09-09','system',NULL,NULL,'History Cooperative ',NULL,NULL,NULL),(456,'2016-09-09','system',NULL,NULL,'Omohundro Institute of Early American History and Culture',NULL,NULL,NULL),(457,'2016-09-09','system',NULL,NULL,'Arms Control Association',NULL,NULL,NULL),(458,'2016-09-09','system',NULL,NULL,'Heritage Archives',NULL,NULL,NULL),(459,'2016-09-09','system',NULL,NULL,'International Historic Films, Inc.',NULL,NULL,NULL),(460,'2016-09-09','system',NULL,NULL,'Euromonitor International ',NULL,NULL,NULL),(461,'2016-09-09','system',NULL,NULL,'Safari Books Online',NULL,NULL,NULL),(462,'2016-09-09','system',NULL,NULL,'Mirabile',NULL,NULL,NULL),(466,'2016-09-09','system',NULL,NULL,'Publishing Technology',NULL,NULL,NULL),(463,'2016-09-09','system',NULL,NULL,'SageWorks, Inc',NULL,NULL,NULL),(464,'2016-09-09','system',NULL,NULL,'Johns Hopkins Universtiy Press',NULL,NULL,NULL),(465,'2016-09-09','system',NULL,NULL,'Knovel ',NULL,NULL,NULL),(467,'2016-09-09','system',NULL,NULL,'American Society of Nephrology',NULL,NULL,NULL),(468,'2016-09-09','system',NULL,NULL,'Water Envrionment Federation ',NULL,NULL,NULL),(469,'2016-09-09','system',NULL,NULL,'Refworks',NULL,NULL,NULL),(470,'2016-09-09','system',NULL,NULL,'Cinemagician Productions',NULL,NULL,NULL),(471,'2016-09-09','system',NULL,NULL,'Algorithmics',NULL,NULL,NULL),(472,'2016-09-09','system',NULL,NULL,'YBP Library Services ',NULL,NULL,NULL),(474,'2016-09-09','system',NULL,NULL,'Maydream Inc.',NULL,NULL,NULL),(475,'2016-09-09','system',NULL,NULL,'Organization for Economic Cooperation and Development',NULL,NULL,NULL),(476,'2016-09-09','system',NULL,NULL,'The Chronicle for Higher Education',NULL,NULL,NULL),(477,'2016-09-09','system',NULL,NULL,'Association for Research in Vision and Ophthalmologie (ARVO)',NULL,NULL,NULL),(478,'2016-09-09','system',NULL,NULL,'SRDS Media Solutions',NULL,NULL,NULL),(479,'2016-09-09','system',NULL,NULL,'Kantar Media',NULL,NULL,NULL),(480,'2016-09-09','system',NULL,NULL,'Peace & Justice Studies Association',NULL,NULL,NULL),(481,'2016-09-09','system',NULL,NULL,'Addison Publications Ltd.',NULL,NULL,NULL),(482,'2016-09-09','system',NULL,NULL,'Mutii-Science Publishing',NULL,NULL,NULL),(483,'2016-09-09','system',NULL,NULL,'ASM International',NULL,NULL,NULL),(484,'2016-09-09','system',NULL,NULL,'Verlag der Osterreichischen Akademie der Wissenschaften',NULL,NULL,NULL),(485,'2016-09-09','system',NULL,NULL,'Anthology of Recorded Music',NULL,NULL,NULL),(486,'2016-09-09','system',NULL,NULL,'Left Coast Press, Inc',NULL,NULL,NULL),(487,'2016-09-09','system',NULL,NULL,'Video Data Bank',NULL,NULL,NULL),(488,'2016-09-09','system',NULL,NULL,'Atlassian',NULL,NULL,NULL),(489,'2016-09-09','system',NULL,NULL,'medici.tv',NULL,NULL,NULL),(490,'2016-09-09','system',NULL,NULL,'Bar Ilan Research & Development Company Ltd',NULL,NULL,NULL),(491,'2016-09-09','system',NULL,NULL,'Primary Source Media',NULL,NULL,NULL),(492,'2016-09-09','system',NULL,NULL,'Ebrary',NULL,NULL,NULL),(493,'2016-09-09','system',NULL,NULL,'University of Michigan, Department of Mathematics',NULL,NULL,NULL),(494,'2016-09-09','system',NULL,NULL,'StataCorp LP ',NULL,NULL,NULL),(495,'2016-09-09','system',NULL,NULL,'L\' Enseignement Mathematique  ',NULL,NULL,NULL),(496,'2016-09-09','system',NULL,NULL,'Audio Engineering Society, Inc',NULL,NULL,NULL),(497,'2016-09-09','system',NULL,NULL,'LOCKSS',NULL,NULL,NULL),(498,'2016-09-09','system',NULL,NULL,'MUSEEC ',NULL,NULL,NULL),(499,'2016-09-09','system',NULL,NULL,'Mortgage Bankers Association',NULL,NULL,NULL),(500,'2016-09-09','system',NULL,NULL,'BibleWorks',NULL,NULL,NULL),(501,'2016-09-09','system',NULL,NULL,'National Library of Ireland',NULL,NULL,NULL),(502,'2016-09-09','system',NULL,NULL,'Scholars Press',NULL,NULL,NULL),(503,'2016-09-09','system',NULL,NULL,'Index to Jewish periodicals',NULL,NULL,NULL),(504,'2016-09-09','system',NULL,NULL,'Cold Spring Harbor Laboratory Press',NULL,NULL,NULL);
+/*!40000 ALTER TABLE `Organization` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrganizationHierarchy`
+--
+
+DROP TABLE IF EXISTS `OrganizationHierarchy`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrganizationHierarchy` (
+  `organizationID` int(11) NOT NULL,
+  `parentOrganizationID` int(11) NOT NULL,
+  PRIMARY KEY (`organizationID`,`parentOrganizationID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrganizationHierarchy`
+--
+
+LOCK TABLES `OrganizationHierarchy` WRITE;
+/*!40000 ALTER TABLE `OrganizationHierarchy` DISABLE KEYS */;
+INSERT INTO `OrganizationHierarchy` VALUES (28,416),(35,411),(43,36),(44,442),(87,433),(154,466),(168,39),(228,29),(259,416),(267,422),(270,51),(301,39),(302,29),(353,51),(354,270),(370,42),(401,402),(406,51),(409,29),(417,416),(420,422),(424,42),(432,87),(439,438),(453,264),(462,297),(469,270),(478,479);
+/*!40000 ALTER TABLE `OrganizationHierarchy` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrganizationRole`
+--
+
+DROP TABLE IF EXISTS `OrganizationRole`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrganizationRole` (
+  `organizationRoleID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`organizationRoleID`),
+  UNIQUE KEY `organizationRoleID` (`organizationRoleID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrganizationRole`
+--
+
+LOCK TABLES `OrganizationRole` WRITE;
+/*!40000 ALTER TABLE `OrganizationRole` DISABLE KEYS */;
+INSERT INTO `OrganizationRole` VALUES (1,'Consortium'),(2,'Library'),(3,'Platform'),(4,'Provider'),(5,'Publisher'),(6,'Vendor');
+/*!40000 ALTER TABLE `OrganizationRole` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrganizationRoleProfile`
+--
+
+DROP TABLE IF EXISTS `OrganizationRoleProfile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrganizationRoleProfile` (
+  `organizationID` int(11) NOT NULL,
+  `organizationRoleID` int(11) NOT NULL,
+  PRIMARY KEY (`organizationID`,`organizationRoleID`),
+  KEY `organizationRoleID` (`organizationRoleID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrganizationRoleProfile`
+--
+
+LOCK TABLES `OrganizationRoleProfile` WRITE;
+/*!40000 ALTER TABLE `OrganizationRoleProfile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `OrganizationRoleProfile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Privilege`
+--
+
+DROP TABLE IF EXISTS `Privilege`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Privilege` (
+  `privilegeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`privilegeID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Privilege`
+--
+
+LOCK TABLES `Privilege` WRITE;
+/*!40000 ALTER TABLE `Privilege` DISABLE KEYS */;
+INSERT INTO `Privilege` VALUES (1,'admin'),(2,'add/edit'),(3,'view only');
+/*!40000 ALTER TABLE `Privilege` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL,
+  `privilegeID` int(11) DEFAULT NULL,
+  `firstName` varchar(50) DEFAULT NULL,
+  `lastName` varchar(50) DEFAULT NULL,
+  `accountTabIndicator` int(1) unsigned DEFAULT '0',
+  PRIMARY KEY (`loginID`) USING BTREE,
+  KEY `roleID` (`privilegeID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test',1,NULL,NULL,0);
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_reports_test`
+--
+
+USE `coral_reports_test`;
+
+--
+-- Table structure for table `Report`
+--
+
+DROP TABLE IF EXISTS `Report`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Report` (
+  `reportID` int(11) NOT NULL AUTO_INCREMENT,
+  `reportName` varchar(45) NOT NULL,
+  `defaultRecPageNumber` int(11) DEFAULT '100',
+  `excelOnlyInd` tinyint(1) DEFAULT NULL,
+  `reportDatabaseName` varchar(45) NOT NULL,
+  PRIMARY KEY (`reportID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Report`
+--
+
+LOCK TABLES `Report` WRITE;
+/*!40000 ALTER TABLE `Report` DISABLE KEYS */;
+INSERT INTO `Report` VALUES (1,'Usage Statistics by Titles',100,0,'usageDatabase'),(2,'Usage Statistics by Provider / Publisher',100,0,'usageDatabase'),(3,'Usage Statistics - Provider Rollup',100,0,'usageDatabase'),(4,'Usage Statistics - Publisher Rollup',100,0,'usageDatabase'),(5,'Usage Statistics - Top Resource Requests',100,0,'usageDatabase'),(6,'Usage Statistics - Yearly Usage Statistics',100,0,'usageDatabase');
+/*!40000 ALTER TABLE `Report` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ReportGroupingColumn`
+--
+
+DROP TABLE IF EXISTS `ReportGroupingColumn`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ReportGroupingColumn` (
+  `reportID` int(11) NOT NULL,
+  `reportGroupingColumnName` varchar(45) NOT NULL,
+  `reportGroupingColumnID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`reportGroupingColumnID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ReportGroupingColumn`
+--
+
+LOCK TABLES `ReportGroupingColumn` WRITE;
+/*!40000 ALTER TABLE `ReportGroupingColumn` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ReportGroupingColumn` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ReportParameter`
+--
+
+DROP TABLE IF EXISTS `ReportParameter`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ReportParameter` (
+  `reportParameterID` int(11) NOT NULL AUTO_INCREMENT,
+  `parameterTypeCode` varchar(45) DEFAULT NULL,
+  `parameterDisplayPrompt` varchar(45) DEFAULT NULL,
+  `parameterAddWhereClause` varchar(500) DEFAULT NULL,
+  `parameterAddWhereNumber` int(11) DEFAULT NULL,
+  `requiredInd` tinyint(1) DEFAULT NULL,
+  `parameterSQLStatement` text,
+  `parameterSQLRestriction` text,
+  PRIMARY KEY (`reportParameterID`)
+) ENGINE=MyISAM AUTO_INCREMENT=16 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ReportParameter`
+--
+
+LOCK TABLES `ReportParameter` WRITE;
+/*!40000 ALTER TABLE `ReportParameter` DISABLE KEYS */;
+INSERT INTO `ReportParameter` VALUES (1,'chk','Do not adjust numbers for use violations','Overriden',0,0,'',''),(2,'txt','ISSN/ISBN/DOI','(ti2.identifier = \'PARM\' OR ti2.identifier = REPLACE(\'PARM\',\"-\",\"\"))',1,0,'',''),(3,'txt','Title Search','upper(t2.title) like upper(\'%PARM%\')',1,0,'',''),(4,'dd','Provider / Publisher','(concat(\'PL_\', CAST(Platform.platformID AS CHAR)) = \'PARM\' OR concat(\'PB_\', CAST(pp.publisherPlatformID AS CHAR)) = \'PARM\')',0,0,'SELECT concat(\'PL_\', CAST(Platform.platformID AS CHAR)), reportDisplayName, upper(reportDisplayName) FROM Platform WHERE reportDropDownInd = 1 UNION SELECT concat(\'PB_\', CAST(publisherPlatformID AS CHAR)), reportDisplayName, upper(reportDisplayName) FROM PublisherPlatform WHERE reportDropDownInd = 1 ORDER BY 3',''),(5,'ms','Provider','concat(\'PL_\', CAST(Platform.platformID AS CHAR)) in (\'PARM\')',0,0,'SELECT concat(\'PL_\', CAST(platformID AS CHAR)), reportDisplayName, upper(reportDisplayName) FROM Platform WHERE reportDropDownInd = 1 ORDER BY 3',''),(6,'ms','Publisher','concat(\'PB_\', CAST(pp.publisherPlatformID AS CHAR)) in (\'PARM\')',0,0,'SELECT GROUP_CONCAT(DISTINCT concat(\'PB_\', CAST(publisherPlatformID AS CHAR)) ORDER BY publisherPlatformID DESC SEPARATOR \', \'), reportDisplayName, upper(reportDisplayName) FROM PublisherPlatform WHERE reportDropDownInd = 1 GROUP BY reportDisplayName ORDER BY 3',''),(7,'dd','Limit','limit',0,1,'SELECT 25,25 union SELECT 50,50 union SELECT 100,100 order by 1',''),(8,'dd','Year','mus.year = \'PARM\'',0,0,'SELECT distinct year, year FROM YearlyUsageSummary ORDER BY 1 asc',''),(9,'dd','Year','mus.year = \'PARM\'',0,0,'SELECT distinct year, year FROM YearlyUsageSummary yus, PublisherPlatform pp WHERE pp.publisherPlatformID=yus.publisherPlatformID ADD_WHERE ORDER BY 1 asc','and (concat(\'PB_\', CAST(yus.publisherPlatformID AS CHAR)) = \'PARM\' or concat(\'PL_\', CAST(pp.platformID AS CHAR)) = \'PARM\')'),(10,'dd','Year','mus.year = \'PARM\'',0,0,'SELECT distinct year, year FROM YearlyUsageSummary yus, PublisherPlatform pp WHERE pp.publisherPlatformID=yus.publisherPlatformID ADD_WHERE ORDER BY 1 asc',''),(11,'dd','Year','yus.year = \'PARM\'',0,0,'SELECT distinct year, year FROM YearlyUsageSummary yus, PublisherPlatform pp WHERE pp.publisherPlatformID=yus.publisherPlatformID ADD_WHERE ORDER BY 1 asc','and (concat(\'PB_\', CAST(yus.publisherPlatformID AS CHAR)) = \'PARM\' or concat(\'PL_\', CAST(pp.platformID AS CHAR)) = \'PARM\')'),(12,'dd','Date Range','',0,1,'SELECT distinct year, year FROM YearlyUsageSummary ORDER BY 1 asc',''),(13,'dd','Date Range','',0,1,'SELECT distinct year, year FROM YearlyUsageSummary yus, PublisherPlatform pp WHERE pp.publisherPlatformID=yus.publisherPlatformID ADD_WHERE ORDER BY 1 asc','and (concat(\'PB_\', CAST(yus.publisherPlatformID AS CHAR)) = \'PARM\' or concat(\'PL_\', CAST(pp.platformID AS CHAR)) = \'PARM\')'),(14,'dd','Date Range','',0,1,'SELECT distinct year, year FROM YearlyUsageSummary yus, PublisherPlatform pp WHERE pp.publisherPlatformID=yus.publisherPlatformID ADD_WHERE ORDER BY 1 asc',''),(15,'dd','Resource Type','t.resourceType= \'PARM\'',0,0,'SELECT distinct resourceType, resourceType FROM Title ORDER BY 1 asc','');
+/*!40000 ALTER TABLE `ReportParameter` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ReportParameterMap`
+--
+
+DROP TABLE IF EXISTS `ReportParameterMap`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ReportParameterMap` (
+  `reportID` int(11) NOT NULL,
+  `reportParameterID` int(11) NOT NULL AUTO_INCREMENT,
+  `parentReportParameterID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`reportID`,`reportParameterID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ReportParameterMap`
+--
+
+LOCK TABLES `ReportParameterMap` WRITE;
+/*!40000 ALTER TABLE `ReportParameterMap` DISABLE KEYS */;
+INSERT INTO `ReportParameterMap` VALUES (1,1,0),(1,2,0),(1,3,0),(1,12,0),(1,15,0),(2,1,0),(2,4,0),(2,13,4),(2,15,0),(3,5,0),(3,14,0),(4,6,0),(4,14,0),(5,1,0),(5,7,0),(5,4,0),(5,11,4),(5,15,0),(6,1,0),(6,4,0),(6,11,4),(6,15,4);
+/*!40000 ALTER TABLE `ReportParameterMap` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ReportSum`
+--
+
+DROP TABLE IF EXISTS `ReportSum`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ReportSum` (
+  `reportID` int(11) NOT NULL,
+  `reportColumnName` varchar(45) NOT NULL,
+  `reportAction` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`reportID`,`reportColumnName`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ReportSum`
+--
+
+LOCK TABLES `ReportSum` WRITE;
+/*!40000 ALTER TABLE `ReportSum` DISABLE KEYS */;
+INSERT INTO `ReportSum` VALUES (1,'JAN','sum'),(1,'FEB','sum'),(1,'MAR','sum'),(1,'APR','sum'),(1,'MAY','sum'),(1,'JUN','sum'),(1,'JUL','sum'),(1,'AUG','sum'),(1,'SEP','sum'),(1,'OCT','sum'),(1,'NOV','sum'),(1,'DEC','sum'),(1,'QUERY_TOTAL','sum'),(1,'YTD_HTML','sum'),(1,'YTD_PDF','sum'),(1,'YTD_TOTAL','sum'),(2,'JAN','sum'),(2,'FEB','sum'),(2,'MAR','sum'),(2,'APR','sum'),(2,'MAY','sum'),(2,'JUN','sum'),(2,'JUL','sum'),(2,'AUG','sum'),(2,'SEP','sum'),(2,'OCT','sum'),(2,'NOV','sum'),(2,'DEC','sum'),(2,'QUERY_TOTAL','sum'),(2,'YTD_HTML','sum'),(2,'YTD_PDF','sum'),(2,'YTD_TOTAL','sum');
+/*!40000 ALTER TABLE `ReportSum` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_resources_test`
+--
+
+USE `coral_resources_test`;
+
+--
+-- Table structure for table `AccessMethod`
+--
+
+DROP TABLE IF EXISTS `AccessMethod`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AccessMethod` (
+  `accessMethodID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`accessMethodID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AccessMethod`
+--
+
+LOCK TABLES `AccessMethod` WRITE;
+/*!40000 ALTER TABLE `AccessMethod` DISABLE KEYS */;
+INSERT INTO `AccessMethod` VALUES (1,'Standalone CD'),(2,'External Host'),(3,'Local Host');
+/*!40000 ALTER TABLE `AccessMethod` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AcquisitionType`
+--
+
+DROP TABLE IF EXISTS `AcquisitionType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AcquisitionType` (
+  `acquisitionTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`acquisitionTypeID`),
+  UNIQUE KEY `acquisitionTypeID` (`acquisitionTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AcquisitionType`
+--
+
+LOCK TABLES `AcquisitionType` WRITE;
+/*!40000 ALTER TABLE `AcquisitionType` DISABLE KEYS */;
+INSERT INTO `AcquisitionType` VALUES (1,'Paid'),(2,'Free'),(3,'Trial');
+/*!40000 ALTER TABLE `AcquisitionType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AdministeringSite`
+--
+
+DROP TABLE IF EXISTS `AdministeringSite`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AdministeringSite` (
+  `administeringSiteID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`administeringSiteID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AdministeringSite`
+--
+
+LOCK TABLES `AdministeringSite` WRITE;
+/*!40000 ALTER TABLE `AdministeringSite` DISABLE KEYS */;
+INSERT INTO `AdministeringSite` VALUES (1,'Main Library');
+/*!40000 ALTER TABLE `AdministeringSite` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AlertDaysInAdvance`
+--
+
+DROP TABLE IF EXISTS `AlertDaysInAdvance`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AlertDaysInAdvance` (
+  `alertDaysInAdvanceID` int(11) NOT NULL AUTO_INCREMENT,
+  `daysInAdvanceNumber` int(11) DEFAULT NULL,
+  PRIMARY KEY (`alertDaysInAdvanceID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AlertDaysInAdvance`
+--
+
+LOCK TABLES `AlertDaysInAdvance` WRITE;
+/*!40000 ALTER TABLE `AlertDaysInAdvance` DISABLE KEYS */;
+INSERT INTO `AlertDaysInAdvance` VALUES (1,30),(2,60),(3,90);
+/*!40000 ALTER TABLE `AlertDaysInAdvance` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AlertEmailAddress`
+--
+
+DROP TABLE IF EXISTS `AlertEmailAddress`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AlertEmailAddress` (
+  `alertEmailAddressID` int(11) NOT NULL AUTO_INCREMENT,
+  `emailAddress` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`alertEmailAddressID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AlertEmailAddress`
+--
+
+LOCK TABLES `AlertEmailAddress` WRITE;
+/*!40000 ALTER TABLE `AlertEmailAddress` DISABLE KEYS */;
+/*!40000 ALTER TABLE `AlertEmailAddress` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Alias`
+--
+
+DROP TABLE IF EXISTS `Alias`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Alias` (
+  `aliasID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `aliasTypeID` int(11) DEFAULT NULL,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`aliasID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_aliasTypeID` (`aliasTypeID`),
+  KEY `shortName` (`shortName`),
+  KEY `Index_All` (`resourceID`,`aliasTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Alias`
+--
+
+LOCK TABLES `Alias` WRITE;
+/*!40000 ALTER TABLE `Alias` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Alias` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AliasType`
+--
+
+DROP TABLE IF EXISTS `AliasType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AliasType` (
+  `aliasTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`aliasTypeID`),
+  UNIQUE KEY `aliasTypeID` (`aliasTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AliasType`
+--
+
+LOCK TABLES `AliasType` WRITE;
+/*!40000 ALTER TABLE `AliasType` DISABLE KEYS */;
+INSERT INTO `AliasType` VALUES (1,'Abbreviation'),(2,'Alternate Name'),(3,'Name Change');
+/*!40000 ALTER TABLE `AliasType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Attachment`
+--
+
+DROP TABLE IF EXISTS `Attachment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Attachment` (
+  `attachmentID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `attachmentTypeID` int(11) DEFAULT NULL,
+  `shortName` varchar(200) DEFAULT NULL,
+  `descriptionText` text,
+  `attachmentURL` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`attachmentID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Attachment`
+--
+
+LOCK TABLES `Attachment` WRITE;
+/*!40000 ALTER TABLE `Attachment` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Attachment` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AttachmentType`
+--
+
+DROP TABLE IF EXISTS `AttachmentType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AttachmentType` (
+  `attachmentTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`attachmentTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AttachmentType`
+--
+
+LOCK TABLES `AttachmentType` WRITE;
+/*!40000 ALTER TABLE `AttachmentType` DISABLE KEYS */;
+INSERT INTO `AttachmentType` VALUES (1,'Email'),(2,'User Guide'),(3,'Title List'),(4,'General');
+/*!40000 ALTER TABLE `AttachmentType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AuthenticationType`
+--
+
+DROP TABLE IF EXISTS `AuthenticationType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AuthenticationType` (
+  `authenticationTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`authenticationTypeID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AuthenticationType`
+--
+
+LOCK TABLES `AuthenticationType` WRITE;
+/*!40000 ALTER TABLE `AuthenticationType` DISABLE KEYS */;
+INSERT INTO `AuthenticationType` VALUES (1,'IP Address'),(2,'Username'),(3,'Referring URL');
+/*!40000 ALTER TABLE `AuthenticationType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `AuthorizedSite`
+--
+
+DROP TABLE IF EXISTS `AuthorizedSite`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `AuthorizedSite` (
+  `authorizedSiteID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`authorizedSiteID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `AuthorizedSite`
+--
+
+LOCK TABLES `AuthorizedSite` WRITE;
+/*!40000 ALTER TABLE `AuthorizedSite` DISABLE KEYS */;
+INSERT INTO `AuthorizedSite` VALUES (1,'Main Campus');
+/*!40000 ALTER TABLE `AuthorizedSite` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `CatalogingStatus`
+--
+
+DROP TABLE IF EXISTS `CatalogingStatus`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `CatalogingStatus` (
+  `catalogingStatusID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`catalogingStatusID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `CatalogingStatus`
+--
+
+LOCK TABLES `CatalogingStatus` WRITE;
+/*!40000 ALTER TABLE `CatalogingStatus` DISABLE KEYS */;
+INSERT INTO `CatalogingStatus` VALUES (1,'Completed'),(2,'Ongoing'),(3,'Rejected');
+/*!40000 ALTER TABLE `CatalogingStatus` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `CatalogingType`
+--
+
+DROP TABLE IF EXISTS `CatalogingType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `CatalogingType` (
+  `catalogingTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`catalogingTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `CatalogingType`
+--
+
+LOCK TABLES `CatalogingType` WRITE;
+/*!40000 ALTER TABLE `CatalogingType` DISABLE KEYS */;
+INSERT INTO `CatalogingType` VALUES (1,'Batch'),(2,'Manual'),(3,'MARCit');
+/*!40000 ALTER TABLE `CatalogingType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Contact`
+--
+
+DROP TABLE IF EXISTS `Contact`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Contact` (
+  `contactID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) NOT NULL,
+  `lastUpdateDate` date DEFAULT NULL,
+  `name` varchar(150) DEFAULT NULL,
+  `title` varchar(150) DEFAULT NULL,
+  `addressText` varchar(300) DEFAULT NULL,
+  `phoneNumber` varchar(50) DEFAULT NULL,
+  `altPhoneNumber` varchar(50) DEFAULT NULL,
+  `faxNumber` varchar(50) DEFAULT NULL,
+  `emailAddress` varchar(100) DEFAULT NULL,
+  `archiveDate` date DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`contactID`),
+  UNIQUE KEY `contactID` (`contactID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Contact`
+--
+
+LOCK TABLES `Contact` WRITE;
+/*!40000 ALTER TABLE `Contact` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Contact` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ContactRole`
+--
+
+DROP TABLE IF EXISTS `ContactRole`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ContactRole` (
+  `contactRoleID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`contactRoleID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ContactRole`
+--
+
+LOCK TABLES `ContactRole` WRITE;
+/*!40000 ALTER TABLE `ContactRole` DISABLE KEYS */;
+INSERT INTO `ContactRole` VALUES (1,'Support'),(2,'Accounting'),(3,'General'),(4,'Licensing'),(5,'Sales'),(6,'Training');
+/*!40000 ALTER TABLE `ContactRole` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ContactRoleProfile`
+--
+
+DROP TABLE IF EXISTS `ContactRoleProfile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ContactRoleProfile` (
+  `contactID` int(10) unsigned NOT NULL,
+  `contactRoleID` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`contactID`,`contactRoleID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ContactRoleProfile`
+--
+
+LOCK TABLES `ContactRoleProfile` WRITE;
+/*!40000 ALTER TABLE `ContactRoleProfile` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ContactRoleProfile` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `CostDetails`
+--
+
+DROP TABLE IF EXISTS `CostDetails`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `CostDetails` (
+  `costDetailsID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) NOT NULL,
+  PRIMARY KEY (`costDetailsID`),
+  KEY `costDetailsID` (`costDetailsID`),
+  KEY `Index_shortName` (`shortName`),
+  KEY `Index_All` (`costDetailsID`,`shortName`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `CostDetails`
+--
+
+LOCK TABLES `CostDetails` WRITE;
+/*!40000 ALTER TABLE `CostDetails` DISABLE KEYS */;
+/*!40000 ALTER TABLE `CostDetails` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Currency`
+--
+
+DROP TABLE IF EXISTS `Currency`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Currency` (
+  `currencyCode` varchar(3) NOT NULL,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`currencyCode`),
+  UNIQUE KEY `currencyCode` (`currencyCode`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Currency`
+--
+
+LOCK TABLES `Currency` WRITE;
+/*!40000 ALTER TABLE `Currency` DISABLE KEYS */;
+INSERT INTO `Currency` VALUES ('USD','United States Dollar'),('EUR','Euro'),('GBP','Great Britain (UK) Pound'),('CAD','Canadian Dollar'),('ARS','Argentine Peso'),('AUD','Australian Dollar'),('SEK','Swedish Krona');
+/*!40000 ALTER TABLE `Currency` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DetailedSubject`
+--
+
+DROP TABLE IF EXISTS `DetailedSubject`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DetailedSubject` (
+  `detailedSubjectID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`detailedSubjectID`),
+  KEY `detailedSubjectID` (`detailedSubjectID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DetailedSubject`
+--
+
+LOCK TABLES `DetailedSubject` WRITE;
+/*!40000 ALTER TABLE `DetailedSubject` DISABLE KEYS */;
+/*!40000 ALTER TABLE `DetailedSubject` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Downtime`
+--
+
+DROP TABLE IF EXISTS `Downtime`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Downtime` (
+  `downtimeID` int(11) NOT NULL AUTO_INCREMENT,
+  `issueID` int(11) DEFAULT NULL,
+  `entityID` int(11) NOT NULL,
+  `entityTypeID` int(11) NOT NULL DEFAULT '2',
+  `creatorID` varchar(80) NOT NULL,
+  `dateCreated` datetime NOT NULL,
+  `startDate` datetime NOT NULL,
+  `endDate` datetime DEFAULT NULL,
+  `downtimeTypeID` int(11) NOT NULL,
+  `note` text,
+  PRIMARY KEY (`downtimeID`),
+  KEY `IssueID` (`issueID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Downtime`
+--
+
+LOCK TABLES `Downtime` WRITE;
+/*!40000 ALTER TABLE `Downtime` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Downtime` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `DowntimeType`
+--
+
+DROP TABLE IF EXISTS `DowntimeType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `DowntimeType` (
+  `downtimeTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(80) NOT NULL,
+  PRIMARY KEY (`downtimeTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `DowntimeType`
+--
+
+LOCK TABLES `DowntimeType` WRITE;
+/*!40000 ALTER TABLE `DowntimeType` DISABLE KEYS */;
+/*!40000 ALTER TABLE `DowntimeType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExternalLogin`
+--
+
+DROP TABLE IF EXISTS `ExternalLogin`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExternalLogin` (
+  `externalLoginID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `externalLoginTypeID` int(11) DEFAULT NULL,
+  `updateDate` date DEFAULT NULL,
+  `loginURL` varchar(150) DEFAULT NULL,
+  `emailAddress` varchar(150) DEFAULT NULL,
+  `username` varchar(50) DEFAULT NULL,
+  `password` varchar(50) DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`externalLoginID`),
+  UNIQUE KEY `externalLoginID` (`externalLoginID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExternalLogin`
+--
+
+LOCK TABLES `ExternalLogin` WRITE;
+/*!40000 ALTER TABLE `ExternalLogin` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExternalLogin` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ExternalLoginType`
+--
+
+DROP TABLE IF EXISTS `ExternalLoginType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExternalLoginType` (
+  `externalLoginTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`externalLoginTypeID`),
+  UNIQUE KEY `externalLoginTypeID` (`externalLoginTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExternalLoginType`
+--
+
+LOCK TABLES `ExternalLoginType` WRITE;
+/*!40000 ALTER TABLE `ExternalLoginType` DISABLE KEYS */;
+INSERT INTO `ExternalLoginType` VALUES (1,'Admin'),(2,'FTP'),(3,'Statistics'),(4,'Support');
+/*!40000 ALTER TABLE `ExternalLoginType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Fund`
+--
+
+DROP TABLE IF EXISTS `Fund`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Fund` (
+  `fundID` int(11) NOT NULL AUTO_INCREMENT,
+  `fundCode` varchar(20) DEFAULT NULL,
+  `shortName` varchar(200) DEFAULT NULL,
+  `archived` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`fundID`),
+  UNIQUE KEY `fundCode` (`fundCode`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Fund`
+--
+
+LOCK TABLES `Fund` WRITE;
+/*!40000 ALTER TABLE `Fund` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Fund` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `GeneralDetailSubjectLink`
+--
+
+DROP TABLE IF EXISTS `GeneralDetailSubjectLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `GeneralDetailSubjectLink` (
+  `generalDetailSubjectLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `generalSubjectID` int(11) DEFAULT NULL,
+  `detailedSubjectID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`generalDetailSubjectLinkID`),
+  KEY `generalDetailSubjectLinkID` (`generalDetailSubjectLinkID`),
+  KEY `Index_All` (`generalSubjectID`,`detailedSubjectID`),
+  KEY `Index_generalSubject` (`generalSubjectID`),
+  KEY `Index_detailedSubject` (`detailedSubjectID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `GeneralDetailSubjectLink`
+--
+
+LOCK TABLES `GeneralDetailSubjectLink` WRITE;
+/*!40000 ALTER TABLE `GeneralDetailSubjectLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `GeneralDetailSubjectLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `GeneralSubject`
+--
+
+DROP TABLE IF EXISTS `GeneralSubject`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `GeneralSubject` (
+  `generalSubjectID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`generalSubjectID`),
+  KEY `generalSubjectID` (`generalSubjectID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `GeneralSubject`
+--
+
+LOCK TABLES `GeneralSubject` WRITE;
+/*!40000 ALTER TABLE `GeneralSubject` DISABLE KEYS */;
+/*!40000 ALTER TABLE `GeneralSubject` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ImportConfig`
+--
+
+DROP TABLE IF EXISTS `ImportConfig`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ImportConfig` (
+  `importConfigID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  `configuration` varchar(1000) DEFAULT NULL,
+  PRIMARY KEY (`importConfigID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ImportConfig`
+--
+
+LOCK TABLES `ImportConfig` WRITE;
+/*!40000 ALTER TABLE `ImportConfig` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ImportConfig` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IsbnOrIssn`
+--
+
+DROP TABLE IF EXISTS `IsbnOrIssn`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IsbnOrIssn` (
+  `isbnOrIssnID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `isbnOrIssn` varchar(45) NOT NULL,
+  PRIMARY KEY (`isbnOrIssnID`),
+  KEY `resourceID` (`resourceID`),
+  KEY `isbnOrIssn` (`isbnOrIssn`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IsbnOrIssn`
+--
+
+LOCK TABLES `IsbnOrIssn` WRITE;
+/*!40000 ALTER TABLE `IsbnOrIssn` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IsbnOrIssn` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Issue`
+--
+
+DROP TABLE IF EXISTS `Issue`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Issue` (
+  `issueID` int(11) NOT NULL AUTO_INCREMENT,
+  `creatorID` varchar(20) NOT NULL,
+  `subjectText` varchar(80) NOT NULL,
+  `bodyText` text NOT NULL,
+  `reminderInterval` int(11) DEFAULT NULL,
+  `dateCreated` datetime NOT NULL,
+  `dateClosed` datetime DEFAULT NULL,
+  `resolutionText` text,
+  PRIMARY KEY (`issueID`),
+  KEY `creatorID` (`creatorID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Issue`
+--
+
+LOCK TABLES `Issue` WRITE;
+/*!40000 ALTER TABLE `Issue` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Issue` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueContact`
+--
+
+DROP TABLE IF EXISTS `IssueContact`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueContact` (
+  `issueContactID` int(11) NOT NULL AUTO_INCREMENT,
+  `issueID` int(11) NOT NULL,
+  `contactID` int(11) NOT NULL,
+  PRIMARY KEY (`issueContactID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueContact`
+--
+
+LOCK TABLES `IssueContact` WRITE;
+/*!40000 ALTER TABLE `IssueContact` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueContact` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueEmail`
+--
+
+DROP TABLE IF EXISTS `IssueEmail`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueEmail` (
+  `issueEmailID` int(11) NOT NULL AUTO_INCREMENT,
+  `issueID` int(11) NOT NULL,
+  `email` varchar(120) NOT NULL,
+  PRIMARY KEY (`issueEmailID`),
+  KEY `IssueID` (`issueID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueEmail`
+--
+
+LOCK TABLES `IssueEmail` WRITE;
+/*!40000 ALTER TABLE `IssueEmail` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueEmail` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueEntityType`
+--
+
+DROP TABLE IF EXISTS `IssueEntityType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueEntityType` (
+  `entityTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `entityName` varchar(80) NOT NULL,
+  PRIMARY KEY (`entityTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueEntityType`
+--
+
+LOCK TABLES `IssueEntityType` WRITE;
+/*!40000 ALTER TABLE `IssueEntityType` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueEntityType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `IssueRelationship`
+--
+
+DROP TABLE IF EXISTS `IssueRelationship`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `IssueRelationship` (
+  `issueRelationshipID` int(11) NOT NULL AUTO_INCREMENT,
+  `issueID` int(11) NOT NULL,
+  `entityID` int(11) NOT NULL,
+  `entityTypeID` int(11) NOT NULL,
+  PRIMARY KEY (`issueRelationshipID`),
+  KEY `issueID` (`issueID`,`entityID`,`entityTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `IssueRelationship`
+--
+
+LOCK TABLES `IssueRelationship` WRITE;
+/*!40000 ALTER TABLE `IssueRelationship` DISABLE KEYS */;
+/*!40000 ALTER TABLE `IssueRelationship` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `LicenseStatus`
+--
+
+DROP TABLE IF EXISTS `LicenseStatus`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `LicenseStatus` (
+  `licenseStatusID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`licenseStatusID`),
+  UNIQUE KEY `licenseStatusID` (`licenseStatusID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `LicenseStatus`
+--
+
+LOCK TABLES `LicenseStatus` WRITE;
+/*!40000 ALTER TABLE `LicenseStatus` DISABLE KEYS */;
+INSERT INTO `LicenseStatus` VALUES (1,'Pending'),(2,'Completed'),(3,'No License Required');
+/*!40000 ALTER TABLE `LicenseStatus` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `NoteType`
+--
+
+DROP TABLE IF EXISTS `NoteType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `NoteType` (
+  `noteTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`noteTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `NoteType`
+--
+
+LOCK TABLES `NoteType` WRITE;
+/*!40000 ALTER TABLE `NoteType` DISABLE KEYS */;
+INSERT INTO `NoteType` VALUES (1,'Product Details'),(2,'Acquisition Details'),(3,'Access Details'),(4,'General'),(5,'Licensing Details'),(6,'Initial Note');
+/*!40000 ALTER TABLE `NoteType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrderType`
+--
+
+DROP TABLE IF EXISTS `OrderType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrderType` (
+  `orderTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`orderTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrderType`
+--
+
+LOCK TABLES `OrderType` WRITE;
+/*!40000 ALTER TABLE `OrderType` DISABLE KEYS */;
+INSERT INTO `OrderType` VALUES (1,'Ongoing'),(2,'One Time');
+/*!40000 ALTER TABLE `OrderType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrgNameMapping`
+--
+
+DROP TABLE IF EXISTS `OrgNameMapping`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrgNameMapping` (
+  `orgNameMappingID` int(11) NOT NULL AUTO_INCREMENT,
+  `importConfigID` int(11) NOT NULL,
+  `orgNameImported` varchar(200) DEFAULT NULL,
+  `orgNameMapped` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`orgNameMappingID`),
+  KEY `importConfigID` (`importConfigID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrgNameMapping`
+--
+
+LOCK TABLES `OrgNameMapping` WRITE;
+/*!40000 ALTER TABLE `OrgNameMapping` DISABLE KEYS */;
+/*!40000 ALTER TABLE `OrgNameMapping` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Organization`
+--
+
+DROP TABLE IF EXISTS `Organization`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Organization` (
+  `organizationID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` tinytext NOT NULL,
+  PRIMARY KEY (`organizationID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=505 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Organization`
+--
+
+LOCK TABLES `Organization` WRITE;
+/*!40000 ALTER TABLE `Organization` DISABLE KEYS */;
+INSERT INTO `Organization` VALUES (2,'Institute of Physics'),(3,'American Institute of Aeronautics and Astronautics'),(4,'American Physical Society'),(5,'American Society of Civil Engineers'),(6,'American Insitute of Physics'),(7,'Society for Industrial and Applied Mathematics'),(8,'TNS Media Intelligence'),(9,'Chemical Abstracts Service'),(10,'Risk Management Association'),(11,'American Concrete Institute'),(12,'American Association for Cancer Research'),(13,'Institution of Engineering and Technology'),(14,'American Economic Association'),(15,'American Mathematical Society'),(16,'American Medical Association'),(18,'Consejo Superior de Investigaciones Cientificas'),(19,'American Meteorological Society'),(20,'American Library Association'),(21,'American Society for Testing and Materials'),(22,'Association of Research Libraries'),(23,'American Society of Limnology and Oceanography'),(24,'Tablet Publishing'),(25,'American Psychological Association'),(26,'American Council of Learned Societies'),(27,'American Association for the Advancement of Science'),(28,'Thomson Healthcare and Science'),(29,'Elsevier'),(30,'JSTOR'),(31,'SAGE Publications'),(32,'American Geophysical Union'),(33,'Annual Reviews'),(34,'BioOne'),(35,'Gale'),(36,'Wiley'),(37,'Oxford University Press'),(38,'Springer'),(39,'Taylor and Francis'),(40,'Stanford University'),(41,'University of California Press'),(42,'EBSCO Publishing'),(43,'Blackwell Publishing'),(44,'Ovid'),(45,'Project Muse'),(46,'American Fisheries Society'),(47,'Neilson Journals Publishing'),(48,'GuideStar USA, Inc'),(49,'Alexander Street Press, LLC'),(50,'Informa Healthcare USA, Inc'),(51,'ProQuest LLC'),(52,'Accessible Archives Inc'),(53,'ACCU Weather Sales and Services, Inc'),(54,'Adam Matthew Digital Ltd'),(55,'Akademiai Kiado'),(56,'World Trade Press'),(57,'World Scientific'),(58,'Walter de Gruyter'),(59,'Cambridge University Press'),(60,'GeoScienceWorld'),(61,'IEEE'),(62,'Yankelovich Inc'),(63,'Nature Publishing Group'),(64,'Verlag der Zeitschrift fur Naturforschung '),(65,'White Horse Press'),(66,'Verlag C.H. Beck'),(67,'Vault, Inc'),(68,'Value Line, Inc'),(69,'Vanderbilt University'),(70,'Uniworld Business Publications, Inc'),(71,'Universum USA'),(72,'University of Wisconsin Press'),(73,'University of Virginia Press'),(74,'University of Toronto Press Inc'),(75,'University of Toronto'),(76,'University of Pittsburgh'),(77,'University of Illinois Press'),(78,'University of Chicago Press'),(79,'University of Barcelona'),(80,'UCLA Chicano Studies Research Center Press'),(81,'Transportation Research Board'),(82,'Trans Tech Publications'),(83,'Thomas Telford Ltd'),(84,'Thesaurus Linguae Graecae'),(85,'Tetrad Computer Applications Inc'),(86,'Swank Motion Pictures, Inc'),(87,'Standard and Poors'),(88,'SPIE'),(89,'European Society of Endocrinology'),(90,'Society of Environmental Toxicology and Chemistry'),(91,'Society of Antiquaries of Scotland'),(92,'Society for Reproduction and Fertility'),(93,'Society for Neuroscience'),(94,'Society for Leukocyte Biology'),(95,'Society for General Microbiology'),(96,'Society for Experimental Biology and Medicine'),(97,'Society for Endocrinology'),(98,'Societe Mathematique de France'),(99,'Social Explorer'),(404,'SETAC'),(101,'Swiss Chemical Society'),(102,'Scholarly Digital Editions'),(103,'Royal Society of London'),(104,'Royal Society of Chemistry'),(105,'Roper Center for Public Opinion Research'),(106,'Rockefeller University Press'),(107,'Rivista di Studi italiani'),(108,'Reuters Loan Pricing Corporation'),(109,'Religious and Theological Abstracts, Inc'),(110,'Psychoanalytic Electronic Publishing Inc'),(111,'Cornell University Library'),(112,'Preservation Technologies LP'),(113,'Portland Press Limited'),(114,'ITHAKA'),(115,'Philosophy Documentation Center'),(116,'Peeters Publishers'),(117,'Paratext'),(118,'Mathematical Sciences Publishers'),(119,'Oxford Centre of Hebrew and Jewish Studies'),(120,'NewsBank, Inc'),(121,'Massachusetts Medical Society'),(122,'Naxos of America, Inc.'),(123,'National Research Council of Canada'),(124,'National Gallery Company Ltd'),(125,'National Academy of Sciences'),(126,'Mintel International Group Limited'),(127,'Metropolitan Opera'),(128,'M.E. Sharpe, Inc'),(129,'Mergent, Inc'),(130,'Mediamark Research and Intelligence, LLC'),(131,'Mary Ann Liebert, Inc'),(132,'MIT Press'),(133,'MarketResearch.com, Inc'),(134,'Marine Biological Laboratory'),(135,'W.S. Maney and Son Ltd'),(136,'Manchester University Press'),(137,'Lord Music Reference Inc'),(138,'Liverpool University Press'),(139,'Seminario Matematico of the University of Padua'),(140,'Library of Congress, Cataloging Distribution Service'),(141,'LexisNexis'),(142,'Corporacion Latinobarometro'),(143,'Landes Bioscience'),(144,'Keesings Worldwide, LLC'),(145,'Karger'),(146,'John Benjamins Publishing Company'),(147,'Irish Newspaper Archives Ltd'),(148,'IPA Source, LLC'),(149,'International Press'),(150,'Intelligence Research Limited'),(151,'Intellect'),(152,'InteLex'),(153,'Institute of Mathematics of the Polish Academy of Sciences'),(154,'Ingentaconnect'),(155,'INFORMS'),(156,'Information Resources, Inc'),(157,'Indiana University Mathematics Journal'),(158,'Incisive Media Ltd'),(159,'IGI Global '),(160,'IBISWorld USA'),(161,'H.W. Wilson Company'),(162,'University of Houston Department of Mathematics'),(163,'Histochemical Society'),(164,'Morningstar Inc.'),(165,'Paradigm Publishers'),(166,'HighWire Press'),(167,'Heldref Publications'),(168,'Haworth Press'),(417,'Thomson Legal'),(170,'IOS Press'),(171,'Agricultural Institute of Canada'),(172,'Allen Press'),(173,'H1 Base, Inc'),(175,'Global Science Press'),(176,'Geographic Research, Inc'),(177,'Genetics Society of America'),(178,'Franz Steiner Verlag'),(179,'Forrester Research, Inc'),(180,'Federation of American Societies for Experimental Biology'),(181,'Faulkner Information Services'),(182,'ExLibris'),(183,'Brill'),(184,'Evolutionary Ecology Ltd'),(185,'European Mathematical Society Publishing House'),(186,'New York Review of Books'),(187,'Dunstans Publishing Ltd'),(188,'Equinox Publishing Ltd'),(189,'Entomological Society of Canada'),(190,'American Association of Immunologists, Inc.'),(191,'Endocrine Society'),(192,'EDP Sciences'),(193,'Edinburgh University Press'),(194,'Ecological Society of America'),(195,'East View Information Services'),(196,'Dun and Bradstreet Inc'),(197,'Duke University Press'),(198,'Digital Distributed Community Archive'),(199,'Albert C. Muller'),(200,'Dialogue Foundation'),(201,'Dialog'),(202,'Current History, Inc'),(203,'CSIRO Publishing'),(204,'CQ Press'),(205,'Japan Focus'),(206,'Carbon Disclosure Project'),(207,'University of Buckingham Press'),(208,'Boopsie, INC.'),(209,'Company of Biologists Ltd'),(210,'Chronicle of Higher Education'),(211,'CCH Incorporated'),(212,'CareerShift LLC'),(213,'Canadian Mathematical Society'),(214,'Cambridge Crystallographic Data Centre'),(215,'CABI Publishing'),(216,'Business Monitor International'),(217,'Bureau of National Affairs, Inc'),(218,'Bulletin of the Atomic Scientists'),(219,'Brepols Publishers'),(221,'Botanical Society of America'),(222,'BMJ Publishing Group Limited'),(223,'BioMed Central'),(224,'Berkeley Electronic Press'),(225,'Berghahn Books'),(226,'Berg Publishers'),(227,'Belser Wissenschaftlicher Dienst Ltd'),(228,'Beilstein Information Systems, Inc'),(229,'Barkhuis Publishing'),(230,'Augustine Institute'),(231,'Asempa Limited'),(232,'ARTstor Inc'),(233,'Applied Probability Trust'),(234,'Antiquity Publications Limited'),(235,'Ammons Scientific Limited'),(236,'American Statistical Association'),(237,'American Society of Tropical Medicine and Hygiene'),(238,'American Society of Plant Biologists'),(239,'Teachers College Record'),(240,'American Society of Agronomy'),(241,'American Society for Nutrition'),(242,'American Society for Horticultural Science'),(243,'American Society for Clinical Investigation'),(244,'American Society for Cell Biology'),(245,'American Psychiatric Publishing'),(246,'American Phytopathological Society'),(247,'American Physiological Society'),(248,'Encyclopaedia Britannica Online'),(249,'Agricultural History Society'),(250,'Begell House, Inc'),(251,'Hans Zell Publishing'),(252,'Alliance for Children and Families'),(253,'Robert Blakemore'),(254,'IVES Group, Inc'),(255,'Massachusetts Institute of Technology'),(256,'Marquis Who\'s Who LLC'),(257,'Atypon Systems Inc'),(258,'Worldwatch Institute'),(259,'Thomson Financial'),(260,'Digital Heritage Publishing Limited'),(261,'U.S. Department of Commerce'),(262,'Lipper Inc'),(263,'Chiniquy Collection'),(264,'OCLC'),(265,'Consumer Electronics Association'),(267,'Institutional Shareholder Services Inc'),(268,'KLD Research and Analytics Inc'),(269,'BIGresearch LLC'),(270,'Cambridge Scientific Abstracts'),(271,'American Institute of Certified Public Accountants'),(272,'Terra Scientific Publishing Company'),(273,'American Counseling Association'),(274,'Army Times Publishing Company'),(275,'Librairie Droz'),(276,'American Academy of Religion'),(277,'Boyd Printing'),(278,'Canadian Association of African Studies'),(279,'Experian Marketing Solutions, Inc.'),(280,'Centro de Investigaciones Sociologicas'),(281,'Chorus America'),(282,'College Art Association'),(283,'Human Kinetics Inc.'),(288,'NERL'),(293,'Colegio de Mexico'),(294,'University of Iowa'),(295,'Academy of the Hebrew Language'),(296,'FamilyLink.com, Inc.'),(297,'SISMEL - Edizioni del Galluzzo'),(301,'Informaworld'),(302,'ScienceDirect'),(304,'China Data Center'),(305,'Association for Computing Machinery'),(306,'American Chemical Society'),(307,'Design Research Publications'),(308,'ABC-CLIO'),(311,'American Association on Intellectual and Developmental Disabilities '),(310,'American Antiquarian Society'),(312,'American Society for Microbiology'),(314,'American Society of Mechanical Engineers'),(315,'Now Publishers, Inc.'),(316,'Cabell Publishing Company, Inc.'),(317,'Center for Research Libraries'),(444,'Cold North Wind Inc'),(321,'Erudit '),(322,'American Institute of Mathematical Sciences'),(324,'American Sociological Association'),(325,'Archaeological Institute of America'),(326,'Bertrand Russell Research Centre'),(328,'Cork University Press'),(329,'College Publishing'),(330,'Council for Learning Disabilities'),(331,'International Society on Hypertension in Blacks (ISHIB)'),(332,'Firenze University Press'),(333,'History of Earth Sciences Society'),(334,'History Today Ltd.'),(335,'Journal of Music'),(336,'University of Nebraska at Omaha'),(337,'Journal of Indo-European Studies'),(338,'Library Binding Institute'),(339,'McFarland & Co. Inc.'),(340,'Lyrasis'),(341,'Amigos Library Services'),(343,'Fabrizio Serra Editore'),(344,'Aux Amateurs'),(346,'National Affairs, Inc'),(357,'Society of Chemical Industry'),(347,'New Criterion'),(348,'Casa Editrice Leo S. Olschki s.r.l.'),(349,'Rhodes University, Department of Philosophy'),(350,'Rocky Mountain Mathematics Consortium'),(352,'Royal Irish Academy'),(353,'Chadwyck-Healey'),(354,'CSA illumina'),(355,'New School for Social Research'),(356,'Society of Biblical Literature'),(358,'Stazione Zoologica Anton Dohrn'),(359,'BioScientifica Ltd.'),(360,'CASALINI LIBRI'),(361,'Institute of Organic Chemistry'),(362,'Columbia International Affairs Online '),(363,'Corporation for National Research Initiatives '),(364,'Tilgher-Genova'),(365,'Emerald Group Publishing Limited'),(366,'Geological Society of America'),(367,'Institute of Mathematical Statistics'),(368,'Institute of Pure and Applied Physics'),(369,'JSTAGE'),(370,'Metapress'),(371,'Modern Language Association'),(372,'Optical Society of America'),(373,'University of British Columbia'),(374,'University of New Mexico'),(375,'Vandenhoeck & Ruprecht'),(376,'Verlag Mohr Siebeck GmbH & Co. KG'),(377,'Palgrave Macmillan'),(378,'Vittorio Klostermann'),(379,'Project Euclid'),(380,'Psychonomic Society '),(411,'Cengage Learning'),(382,'Infotrieve'),(383,'Society of Automotive Engineers'),(384,'Turpion Publications'),(426,'Midwest Collaborative for Library Services'),(386,'Lawrence Erlbaum Associates'),(387,'Alphagraphics'),(388,'Bellerophon Publications, Inc.'),(389,'Boydell & Brewer Inc.'),(390,'Carcanet Press'),(391,'Feminist Studies'),(393,'Dustbooks'),(394,'Society for Applied Anthropology '),(395,'United Nations Publications'),(396,'Wharton Research Data Services'),(398,'Human Development'),(399,'infoUSA Marketing, Inc.'),(400,'Bowker'),(402,'Brown University'),(401,'Women Writers Project'),(445,'Coutts'),(446,'Numara Software, Inc.'),(447,'Trinity College Library Dublin'),(405,'Oldenbourg Wissenschaftsverlag '),(406,'Dow Jones'),(412,'Financial Information Inc. (FII)'),(408,'Jackson Publishing and Distribution'),(409,'Elsevier Engineering Information, Inc. '),(410,'Eneclann Ltd.'),(413,'UCLA Latin American Institute'),(414,'Harmonie Park Press '),(415,'Harrassowitz'),(416,'Thomson Reuters'),(418,'Human Relations Area Files, Inc. '),(432,'Capital IQ'),(419,'Society for Ethnomusicology'),(420,'MSCI RiskMetrics'),(421,'Rapid Multimedia'),(422,'MSCI Inc'),(423,'New England Journal of Medicine'),(424,'NetLibrary'),(425,'CARMA'),(427,'Public Library of Science'),(428,'Social Science Electronic Publishing'),(429,'United Nations Industrial Develoipment Organization'),(430,'University of Michigan Press'),(431,'ORS Publishing, Inc.'),(433,'McGraw-Hill'),(434,'Biblical Archaeology Society'),(435,'GeoLytics, Inc.'),(436,'JoVE '),(437,'ICEsoft Technologies, Inc.'),(438,'Films Media Group'),(439,'Films on Demand'),(440,'Connect Journals'),(441,'Scuola Normale Superiore'),(442,'Wolters Kluwer'),(448,'Pier Professional'),(449,'ABC News'),(450,'University of Aberdeen '),(451,'BullFrog Films, Inc.'),(453,'FirstSearch'),(455,'History Cooperative '),(456,'Omohundro Institute of Early American History and Culture'),(457,'Arms Control Association'),(458,'Heritage Archives'),(459,'International Historic Films, Inc.'),(460,'Euromonitor International '),(461,'Safari Books Online'),(462,'Mirabile'),(466,'Publishing Technology'),(463,'SageWorks, Inc'),(464,'Johns Hopkins Universtiy Press'),(465,'Knovel '),(467,'American Society of Nephrology'),(468,'Water Envrionment Federation '),(469,'Refworks'),(470,'Cinemagician Productions'),(471,'Algorithmics'),(472,'YBP Library Services '),(474,'Maydream Inc.'),(475,'Organization for Economic Cooperation and Development'),(476,'The Chronicle for Higher Education'),(477,'Association for Research in Vision and Ophthalmologie (ARVO)'),(478,'SRDS Media Solutions'),(479,'Kantar Media'),(480,'Peace & Justice Studies Association'),(481,'Addison Publications Ltd.'),(482,'Mutii-Science Publishing'),(483,'ASM International'),(484,'Verlag der Osterreichischen Akademie der Wissenschaften'),(485,'Anthology of Recorded Music'),(486,'Left Coast Press, Inc'),(487,'Video Data Bank'),(488,'Atlassian'),(489,'medici.tv'),(490,'Bar Ilan Research & Development Company Ltd'),(491,'Primary Source Media'),(492,'Ebrary'),(493,'University of Michigan, Department of Mathematics'),(494,'StataCorp LP '),(495,'L\' Enseignement Mathematique  '),(496,'Audio Engineering Society, Inc'),(497,'LOCKSS'),(498,'MUSEEC '),(499,'Mortgage Bankers Association'),(500,'BibleWorks'),(501,'National Library of Ireland'),(502,'Scholars Press'),(503,'Index to Jewish periodicals'),(504,'Cold Spring Harbor Laboratory Press');
+/*!40000 ALTER TABLE `Organization` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `OrganizationRole`
+--
+
+DROP TABLE IF EXISTS `OrganizationRole`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `OrganizationRole` (
+  `organizationRoleID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`organizationRoleID`),
+  UNIQUE KEY `organizationRoleID` (`organizationRoleID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `OrganizationRole`
+--
+
+LOCK TABLES `OrganizationRole` WRITE;
+/*!40000 ALTER TABLE `OrganizationRole` DISABLE KEYS */;
+INSERT INTO `OrganizationRole` VALUES (1,'Consortium'),(2,'Library'),(3,'Platform'),(4,'Provider'),(5,'Publisher'),(6,'Vendor');
+/*!40000 ALTER TABLE `OrganizationRole` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Privilege`
+--
+
+DROP TABLE IF EXISTS `Privilege`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Privilege` (
+  `privilegeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`privilegeID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Privilege`
+--
+
+LOCK TABLES `Privilege` WRITE;
+/*!40000 ALTER TABLE `Privilege` DISABLE KEYS */;
+INSERT INTO `Privilege` VALUES (1,'admin'),(2,'add/edit'),(3,'view only');
+/*!40000 ALTER TABLE `Privilege` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `PurchaseSite`
+--
+
+DROP TABLE IF EXISTS `PurchaseSite`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PurchaseSite` (
+  `purchaseSiteID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`purchaseSiteID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `PurchaseSite`
+--
+
+LOCK TABLES `PurchaseSite` WRITE;
+/*!40000 ALTER TABLE `PurchaseSite` DISABLE KEYS */;
+INSERT INTO `PurchaseSite` VALUES (1,'Main Library');
+/*!40000 ALTER TABLE `PurchaseSite` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `RelationshipType`
+--
+
+DROP TABLE IF EXISTS `RelationshipType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `RelationshipType` (
+  `relationshipTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`relationshipTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `RelationshipType`
+--
+
+LOCK TABLES `RelationshipType` WRITE;
+/*!40000 ALTER TABLE `RelationshipType` DISABLE KEYS */;
+INSERT INTO `RelationshipType` VALUES (1,'Parent'),(2,'General');
+/*!40000 ALTER TABLE `RelationshipType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Resource`
+--
+
+DROP TABLE IF EXISTS `Resource`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Resource` (
+  `resourceID` int(11) NOT NULL AUTO_INCREMENT,
+  `createDate` date DEFAULT NULL,
+  `createLoginID` varchar(45) DEFAULT NULL,
+  `updateDate` date DEFAULT NULL,
+  `updateLoginID` varchar(45) DEFAULT NULL,
+  `archiveDate` date DEFAULT NULL,
+  `archiveLoginID` varchar(45) DEFAULT NULL,
+  `workflowRestartDate` date DEFAULT NULL,
+  `workflowRestartLoginID` varchar(45) DEFAULT NULL,
+  `titleText` varchar(200) DEFAULT NULL,
+  `descriptionText` text,
+  `statusID` int(11) DEFAULT NULL,
+  `resourceTypeID` int(11) DEFAULT NULL,
+  `resourceFormatID` int(11) DEFAULT NULL,
+  `orderNumber` varchar(45) DEFAULT NULL,
+  `systemNumber` varchar(45) DEFAULT NULL,
+  `currentStartDate` date DEFAULT NULL,
+  `currentEndDate` date DEFAULT NULL,
+  `subscriptionAlertEnabledInd` int(10) unsigned DEFAULT NULL,
+  `userLimitID` int(11) DEFAULT NULL,
+  `resourceURL` varchar(2000) DEFAULT NULL,
+  `authenticationUserName` varchar(200) DEFAULT NULL,
+  `authenticationPassword` varchar(200) DEFAULT NULL,
+  `storageLocationID` int(11) DEFAULT NULL,
+  `registeredIPAddresses` varchar(200) DEFAULT NULL,
+  `acquisitionTypeID` int(10) unsigned DEFAULT NULL,
+  `authenticationTypeID` int(10) unsigned DEFAULT NULL,
+  `accessMethodID` int(10) unsigned DEFAULT NULL,
+  `providerText` varchar(200) DEFAULT NULL,
+  `recordSetIdentifier` varchar(45) DEFAULT NULL,
+  `hasOclcHoldings` varchar(10) DEFAULT NULL,
+  `numberRecordsAvailable` varchar(45) DEFAULT NULL,
+  `numberRecordsLoaded` varchar(45) DEFAULT NULL,
+  `bibSourceURL` varchar(2000) DEFAULT NULL,
+  `catalogingTypeID` int(11) DEFAULT NULL,
+  `catalogingStatusID` int(11) DEFAULT NULL,
+  `coverageText` varchar(1000) DEFAULT NULL,
+  `resourceAltURL` varchar(2000) DEFAULT NULL,
+  PRIMARY KEY (`resourceID`),
+  KEY `Index_createDate` (`createDate`),
+  KEY `Index_createLoginID` (`createLoginID`),
+  KEY `Index_titleText` (`titleText`),
+  KEY `Index_statusID` (`statusID`),
+  KEY `Index_resourceTypeID` (`resourceTypeID`),
+  KEY `Index_resourceFormatID` (`resourceFormatID`),
+  KEY `Index_acquisitionTypeID` (`authenticationTypeID`),
+  KEY `catalogingTypeID` (`catalogingTypeID`),
+  KEY `catalogingStatusID` (`catalogingStatusID`),
+  KEY `Index_All` (`createDate`,`createLoginID`,`titleText`,`statusID`,`resourceTypeID`,`resourceFormatID`,`acquisitionTypeID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Resource`
+--
+
+LOCK TABLES `Resource` WRITE;
+/*!40000 ALTER TABLE `Resource` DISABLE KEYS */;
+INSERT INTO `Resource` VALUES (1,'2016-09-09','coral_test',NULL,NULL,NULL,NULL,NULL,NULL,'My Resource',NULL,1,NULL,2,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,1,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);
+/*!40000 ALTER TABLE `Resource` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceAdministeringSiteLink`
+--
+
+DROP TABLE IF EXISTS `ResourceAdministeringSiteLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceAdministeringSiteLink` (
+  `resourceAdministeringSiteLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `administeringSiteID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceAdministeringSiteLinkID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_administeringSiteID` (`administeringSiteID`),
+  KEY `Index_All` (`resourceID`,`administeringSiteID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceAdministeringSiteLink`
+--
+
+LOCK TABLES `ResourceAdministeringSiteLink` WRITE;
+/*!40000 ALTER TABLE `ResourceAdministeringSiteLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceAdministeringSiteLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceAlert`
+--
+
+DROP TABLE IF EXISTS `ResourceAlert`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceAlert` (
+  `resourceAlertID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `loginID` varchar(45) DEFAULT NULL,
+  `sendDate` date DEFAULT NULL,
+  `alertText` text,
+  PRIMARY KEY (`resourceAlertID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceAlert`
+--
+
+LOCK TABLES `ResourceAlert` WRITE;
+/*!40000 ALTER TABLE `ResourceAlert` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceAlert` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceAuthorizedSiteLink`
+--
+
+DROP TABLE IF EXISTS `ResourceAuthorizedSiteLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceAuthorizedSiteLink` (
+  `resourceAuthorizedSiteLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `authorizedSiteID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceAuthorizedSiteLinkID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_authorizedSiteID` (`authorizedSiteID`),
+  KEY `Index_All` (`resourceID`,`authorizedSiteID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceAuthorizedSiteLink`
+--
+
+LOCK TABLES `ResourceAuthorizedSiteLink` WRITE;
+/*!40000 ALTER TABLE `ResourceAuthorizedSiteLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceAuthorizedSiteLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceFormat`
+--
+
+DROP TABLE IF EXISTS `ResourceFormat`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceFormat` (
+  `resourceFormatID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`resourceFormatID`) USING BTREE,
+  KEY `shortName` (`shortName`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceFormat`
+--
+
+LOCK TABLES `ResourceFormat` WRITE;
+/*!40000 ALTER TABLE `ResourceFormat` DISABLE KEYS */;
+INSERT INTO `ResourceFormat` VALUES (1,'Print + Electronic'),(2,'Electronic');
+/*!40000 ALTER TABLE `ResourceFormat` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceLicenseLink`
+--
+
+DROP TABLE IF EXISTS `ResourceLicenseLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceLicenseLink` (
+  `resourceLicenseLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `licenseID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceLicenseLinkID`),
+  KEY `resourceID` (`resourceID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceLicenseLink`
+--
+
+LOCK TABLES `ResourceLicenseLink` WRITE;
+/*!40000 ALTER TABLE `ResourceLicenseLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceLicenseLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceLicenseStatus`
+--
+
+DROP TABLE IF EXISTS `ResourceLicenseStatus`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceLicenseStatus` (
+  `resourceLicenseStatusID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `licenseStatusID` int(11) DEFAULT NULL,
+  `licenseStatusChangeDate` datetime DEFAULT NULL,
+  `licenseStatusChangeLoginID` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`resourceLicenseStatusID`),
+  KEY `resourceID` (`resourceID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceLicenseStatus`
+--
+
+LOCK TABLES `ResourceLicenseStatus` WRITE;
+/*!40000 ALTER TABLE `ResourceLicenseStatus` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceLicenseStatus` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceNote`
+--
+
+DROP TABLE IF EXISTS `ResourceNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceNote` (
+  `resourceNoteID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `noteTypeID` int(11) DEFAULT NULL,
+  `tabName` varchar(45) DEFAULT NULL,
+  `updateDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updateLoginID` varchar(45) DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`resourceNoteID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_noteTypeID` (`noteTypeID`),
+  KEY `Index_All` (`resourceID`,`noteTypeID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceNote`
+--
+
+LOCK TABLES `ResourceNote` WRITE;
+/*!40000 ALTER TABLE `ResourceNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceOrganizationLink`
+--
+
+DROP TABLE IF EXISTS `ResourceOrganizationLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceOrganizationLink` (
+  `resourceOrganizationLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `organizationID` int(11) DEFAULT NULL,
+  `organizationRoleID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceOrganizationLinkID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_organizationID` (`organizationID`),
+  KEY `Index_All` (`resourceID`,`organizationID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceOrganizationLink`
+--
+
+LOCK TABLES `ResourceOrganizationLink` WRITE;
+/*!40000 ALTER TABLE `ResourceOrganizationLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceOrganizationLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourcePayment`
+--
+
+DROP TABLE IF EXISTS `ResourcePayment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourcePayment` (
+  `resourcePaymentID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(10) unsigned NOT NULL,
+  `fundID` int(10) DEFAULT NULL,
+  `selectorLoginID` varchar(45) DEFAULT NULL,
+  `priceTaxExcluded` int(10) unsigned DEFAULT NULL,
+  `taxRate` int(10) unsigned DEFAULT NULL,
+  `priceTaxIncluded` int(10) unsigned DEFAULT NULL,
+  `paymentAmount` int(10) unsigned DEFAULT NULL,
+  `orderTypeID` int(10) unsigned DEFAULT NULL,
+  `currencyCode` varchar(3) NOT NULL,
+  `year` varchar(20) DEFAULT NULL,
+  `subscriptionStartDate` date DEFAULT NULL,
+  `subscriptionEndDate` date DEFAULT NULL,
+  `costDetailsID` int(11) DEFAULT NULL,
+  `costNote` text,
+  `invoiceNum` varchar(20) DEFAULT NULL,
+  PRIMARY KEY (`resourcePaymentID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_fundID` (`fundID`),
+  KEY `Index_year` (`year`),
+  KEY `Index_costDetailsID` (`costDetailsID`),
+  KEY `Index_invoiceNum` (`invoiceNum`),
+  KEY `Index_All` (`resourceID`,`fundID`,`year`,`costDetailsID`,`invoiceNum`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourcePayment`
+--
+
+LOCK TABLES `ResourcePayment` WRITE;
+/*!40000 ALTER TABLE `ResourcePayment` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourcePayment` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourcePurchaseSiteLink`
+--
+
+DROP TABLE IF EXISTS `ResourcePurchaseSiteLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourcePurchaseSiteLink` (
+  `resourcePurchaseSiteLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `purchaseSiteID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourcePurchaseSiteLinkID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_purchaseSiteID` (`purchaseSiteID`),
+  KEY `Index_All` (`resourceID`,`purchaseSiteID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourcePurchaseSiteLink`
+--
+
+LOCK TABLES `ResourcePurchaseSiteLink` WRITE;
+/*!40000 ALTER TABLE `ResourcePurchaseSiteLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourcePurchaseSiteLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceRelationship`
+--
+
+DROP TABLE IF EXISTS `ResourceRelationship`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceRelationship` (
+  `resourceRelationshipID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `relatedResourceID` int(11) DEFAULT NULL,
+  `relationshipTypeID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceRelationshipID`),
+  KEY `Index_resourceID` (`resourceID`),
+  KEY `Index_relatedResourceID` (`relatedResourceID`),
+  KEY `Index_All` (`resourceID`,`relatedResourceID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceRelationship`
+--
+
+LOCK TABLES `ResourceRelationship` WRITE;
+/*!40000 ALTER TABLE `ResourceRelationship` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceRelationship` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceStep`
+--
+
+DROP TABLE IF EXISTS `ResourceStep`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceStep` (
+  `resourceStepID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `stepID` int(11) DEFAULT NULL,
+  `stepStartDate` date DEFAULT NULL,
+  `stepEndDate` date DEFAULT NULL,
+  `endLoginID` varchar(200) DEFAULT NULL,
+  `priorStepID` int(11) DEFAULT NULL,
+  `stepName` varchar(200) DEFAULT NULL,
+  `userGroupID` int(11) DEFAULT NULL,
+  `displayOrderSequence` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`resourceStepID`),
+  KEY `resourceID` (`resourceID`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceStep`
+--
+
+LOCK TABLES `ResourceStep` WRITE;
+/*!40000 ALTER TABLE `ResourceStep` DISABLE KEYS */;
+INSERT INTO `ResourceStep` VALUES (1,1,1,'2016-09-09',NULL,NULL,NULL,'Funding Approval',3,1),(2,1,2,'2016-09-09',NULL,NULL,NULL,'Licensing',2,2),(3,1,3,NULL,NULL,NULL,2,'Order Processing',4,3),(4,1,4,NULL,NULL,NULL,3,'Activation',1,4);
+/*!40000 ALTER TABLE `ResourceStep` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceSubject`
+--
+
+DROP TABLE IF EXISTS `ResourceSubject`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceSubject` (
+  `resourceSubjectID` int(11) NOT NULL AUTO_INCREMENT,
+  `resourceID` int(11) DEFAULT NULL,
+  `generalDetailSubjectLinkID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`resourceSubjectID`),
+  KEY `resourceSubjectID` (`resourceSubjectID`),
+  KEY `Index_All` (`resourceID`,`generalDetailSubjectLinkID`),
+  KEY `Index_ResourceID` (`resourceID`),
+  KEY `Index_GeneralDetailLink` (`generalDetailSubjectLinkID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceSubject`
+--
+
+LOCK TABLES `ResourceSubject` WRITE;
+/*!40000 ALTER TABLE `ResourceSubject` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ResourceSubject` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ResourceType`
+--
+
+DROP TABLE IF EXISTS `ResourceType`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ResourceType` (
+  `resourceTypeID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  `includeStats` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`resourceTypeID`),
+  KEY `shortName` (`shortName`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ResourceType`
+--
+
+LOCK TABLES `ResourceType` WRITE;
+/*!40000 ALTER TABLE `ResourceType` DISABLE KEYS */;
+INSERT INTO `ResourceType` VALUES (1,'My Resource Type',NULL);
+/*!40000 ALTER TABLE `ResourceType` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Status`
+--
+
+DROP TABLE IF EXISTS `Status`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Status` (
+  `statusID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`statusID`),
+  KEY `shortName` (`shortName`)
+) ENGINE=MyISAM AUTO_INCREMENT=5 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Status`
+--
+
+LOCK TABLES `Status` WRITE;
+/*!40000 ALTER TABLE `Status` DISABLE KEYS */;
+INSERT INTO `Status` VALUES (1,'In Progress'),(2,'Completed'),(3,'Saved'),(4,'Archived');
+/*!40000 ALTER TABLE `Status` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Step`
+--
+
+DROP TABLE IF EXISTS `Step`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Step` (
+  `stepID` int(11) NOT NULL AUTO_INCREMENT,
+  `priorStepID` int(11) DEFAULT NULL,
+  `stepName` varchar(200) DEFAULT NULL,
+  `userGroupID` int(11) DEFAULT NULL,
+  `workflowID` int(11) DEFAULT NULL,
+  `displayOrderSequence` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`stepID`)
+) ENGINE=MyISAM AUTO_INCREMENT=7 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Step`
+--
+
+LOCK TABLES `Step` WRITE;
+/*!40000 ALTER TABLE `Step` DISABLE KEYS */;
+INSERT INTO `Step` VALUES (1,NULL,'Funding Approval',3,1,1),(2,NULL,'Licensing',2,1,2),(3,2,'Order Processing',4,1,3),(4,3,'Activation',1,1,4),(5,NULL,'Licensing',2,2,1),(6,NULL,'Activation',1,2,2);
+/*!40000 ALTER TABLE `Step` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `StorageLocation`
+--
+
+DROP TABLE IF EXISTS `StorageLocation`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `StorageLocation` (
+  `storageLocationID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`storageLocationID`)
+) ENGINE=MyISAM AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `StorageLocation`
+--
+
+LOCK TABLES `StorageLocation` WRITE;
+/*!40000 ALTER TABLE `StorageLocation` DISABLE KEYS */;
+INSERT INTO `StorageLocation` VALUES (1,'Reserve Book Room');
+/*!40000 ALTER TABLE `StorageLocation` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL DEFAULT '',
+  `lastName` varchar(45) DEFAULT NULL,
+  `firstName` varchar(45) DEFAULT NULL,
+  `privilegeID` int(10) unsigned DEFAULT NULL,
+  `accountTabIndicator` int(1) unsigned DEFAULT '0',
+  `emailAddress` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`loginID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test',NULL,NULL,1,0,NULL);
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `UserGroup`
+--
+
+DROP TABLE IF EXISTS `UserGroup`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `UserGroup` (
+  `userGroupID` int(11) NOT NULL AUTO_INCREMENT,
+  `groupName` varchar(200) DEFAULT NULL,
+  `emailAddress` varchar(200) DEFAULT NULL,
+  `emailText` varchar(2000) DEFAULT NULL,
+  PRIMARY KEY (`userGroupID`)
+) ENGINE=MyISAM AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `UserGroup`
+--
+
+LOCK TABLES `UserGroup` WRITE;
+/*!40000 ALTER TABLE `UserGroup` DISABLE KEYS */;
+INSERT INTO `UserGroup` VALUES (1,'Access',NULL,NULL),(2,'Licensing',NULL,NULL),(3,'Funding Approval',NULL,NULL),(4,'Acquisitions',NULL,NULL),(5,'Receipt',NULL,NULL);
+/*!40000 ALTER TABLE `UserGroup` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `UserGroupLink`
+--
+
+DROP TABLE IF EXISTS `UserGroupLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `UserGroupLink` (
+  `userGroupLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `loginID` varchar(200) DEFAULT NULL,
+  `userGroupID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`userGroupLinkID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `UserGroupLink`
+--
+
+LOCK TABLES `UserGroupLink` WRITE;
+/*!40000 ALTER TABLE `UserGroupLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `UserGroupLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `UserLimit`
+--
+
+DROP TABLE IF EXISTS `UserLimit`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `UserLimit` (
+  `userLimitID` int(11) NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`userLimitID`)
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `UserLimit`
+--
+
+LOCK TABLES `UserLimit` WRITE;
+/*!40000 ALTER TABLE `UserLimit` DISABLE KEYS */;
+INSERT INTO `UserLimit` VALUES (1,'1'),(2,'2'),(3,'3'),(4,'4'),(5,'5'),(6,'6'),(7,'7'),(8,'8'),(9,'9'),(10,'10+');
+/*!40000 ALTER TABLE `UserLimit` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Workflow`
+--
+
+DROP TABLE IF EXISTS `Workflow`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Workflow` (
+  `workflowID` int(11) NOT NULL AUTO_INCREMENT,
+  `workflowName` varchar(200) DEFAULT NULL,
+  `resourceFormatIDValue` varchar(45) DEFAULT NULL,
+  `resourceTypeIDValue` varchar(45) DEFAULT NULL,
+  `acquisitionTypeIDValue` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`workflowID`)
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Workflow`
+--
+
+LOCK TABLES `Workflow` WRITE;
+/*!40000 ALTER TABLE `Workflow` DISABLE KEYS */;
+INSERT INTO `Workflow` VALUES (1,NULL,'2','','1'),(2,NULL,'2','','2');
+/*!40000 ALTER TABLE `Workflow` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Current Database: `coral_usage_test`
+--
+
+USE `coral_usage_test`;
+
+--
+-- Table structure for table `ExternalLogin`
+--
+
+DROP TABLE IF EXISTS `ExternalLogin`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ExternalLogin` (
+  `externalLoginID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `publisherPlatformID` int(10) unsigned DEFAULT NULL,
+  `platformID` int(10) unsigned DEFAULT NULL,
+  `username` varchar(45) DEFAULT NULL,
+  `password` varchar(45) DEFAULT NULL,
+  `loginURL` varchar(245) DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`externalLoginID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ExternalLogin`
+--
+
+LOCK TABLES `ExternalLogin` WRITE;
+/*!40000 ALTER TABLE `ExternalLogin` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ExternalLogin` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ImportLog`
+--
+
+DROP TABLE IF EXISTS `ImportLog`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ImportLog` (
+  `importLogID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `loginID` varchar(45) NOT NULL,
+  `importDateTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `layoutCode` varchar(45) DEFAULT NULL,
+  `fileName` varchar(45) DEFAULT NULL,
+  `archiveFileURL` varchar(145) DEFAULT NULL,
+  `logFileURL` varchar(145) DEFAULT NULL,
+  `details` varchar(245) DEFAULT NULL,
+  PRIMARY KEY (`importLogID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ImportLog`
+--
+
+LOCK TABLES `ImportLog` WRITE;
+/*!40000 ALTER TABLE `ImportLog` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ImportLog` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `ImportLogPlatformLink`
+--
+
+DROP TABLE IF EXISTS `ImportLogPlatformLink`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ImportLogPlatformLink` (
+  `importLogPlatformLinkID` int(11) NOT NULL AUTO_INCREMENT,
+  `platformID` int(11) DEFAULT NULL,
+  `importLogID` int(11) DEFAULT NULL,
+  PRIMARY KEY (`importLogPlatformLinkID`),
+  KEY `Index_platformID` (`platformID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `ImportLogPlatformLink`
+--
+
+LOCK TABLES `ImportLogPlatformLink` WRITE;
+/*!40000 ALTER TABLE `ImportLogPlatformLink` DISABLE KEYS */;
+/*!40000 ALTER TABLE `ImportLogPlatformLink` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Layout`
+--
+
+DROP TABLE IF EXISTS `Layout`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Layout` (
+  `layoutID` int(11) NOT NULL AUTO_INCREMENT,
+  `layoutCode` varchar(45) NOT NULL,
+  `name` varchar(45) DEFAULT NULL,
+  `resourceType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`layoutID`)
+) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Layout`
+--
+
+LOCK TABLES `Layout` WRITE;
+/*!40000 ALTER TABLE `Layout` DISABLE KEYS */;
+INSERT INTO `Layout` VALUES (1,'JR1_R3','Journals (JR1) R3','Journal'),(2,'JR1a_R3','Journals (JR1) R3 archive','Journal'),(3,'JR1_R4','Journals (JR1) R4','Journal'),(4,'JR1a_R4','Journals (JR1) R4 archive','Journal'),(5,'BR1_R3','Books (BR1) R3','Book'),(6,'BR1_R4','Books (BR1) R4','Book'),(7,'BR2_R3','Book Sections (BR2) R3','Book'),(8,'BR2_R4','Book Sections (BR2) R4','Book'),(9,'DB1_R3','Database (DB1) R3','Database'),(10,'DB1_R4','Database (DB1) R4','Database');
+/*!40000 ALTER TABLE `Layout` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `LogEmailAddress`
+--
+
+DROP TABLE IF EXISTS `LogEmailAddress`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `LogEmailAddress` (
+  `logEmailAddressID` int(11) NOT NULL AUTO_INCREMENT,
+  `emailAddress` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`logEmailAddressID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `LogEmailAddress`
+--
+
+LOCK TABLES `LogEmailAddress` WRITE;
+/*!40000 ALTER TABLE `LogEmailAddress` DISABLE KEYS */;
+/*!40000 ALTER TABLE `LogEmailAddress` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `MonthlyUsageSummary`
+--
+
+DROP TABLE IF EXISTS `MonthlyUsageSummary`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `MonthlyUsageSummary` (
+  `monthlyUsageSummaryID` int(11) NOT NULL AUTO_INCREMENT,
+  `titleID` int(11) NOT NULL,
+  `publisherPlatformID` int(11) NOT NULL,
+  `year` int(4) NOT NULL,
+  `month` int(2) NOT NULL,
+  `archiveInd` tinyint(1) DEFAULT NULL,
+  `usageCount` int(11) DEFAULT NULL,
+  `overrideUsageCount` int(11) DEFAULT NULL,
+  `outlierID` int(10) unsigned DEFAULT NULL,
+  `ignoreOutlierInd` tinyint(3) unsigned DEFAULT '0',
+  `mergeInd` tinyint(1) unsigned DEFAULT '0',
+  `activityType` varchar(45) DEFAULT NULL,
+  `sectionType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`monthlyUsageSummaryID`) USING BTREE,
+  KEY `Index_titleID` (`titleID`),
+  KEY `Index_publisherPlatformID` (`publisherPlatformID`),
+  KEY `Index_year` (`year`),
+  KEY `Index_TPPYMA` (`titleID`,`publisherPlatformID`,`year`,`month`,`archiveInd`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `MonthlyUsageSummary`
+--
+
+LOCK TABLES `MonthlyUsageSummary` WRITE;
+/*!40000 ALTER TABLE `MonthlyUsageSummary` DISABLE KEYS */;
+/*!40000 ALTER TABLE `MonthlyUsageSummary` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Outlier`
+--
+
+DROP TABLE IF EXISTS `Outlier`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Outlier` (
+  `outlierID` int(11) NOT NULL AUTO_INCREMENT,
+  `outlierLevel` int(11) DEFAULT NULL,
+  `overageCount` int(11) DEFAULT NULL,
+  `overagePercent` int(3) DEFAULT NULL,
+  `color` varchar(45) NOT NULL,
+  PRIMARY KEY (`outlierID`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Outlier`
+--
+
+LOCK TABLES `Outlier` WRITE;
+/*!40000 ALTER TABLE `Outlier` DISABLE KEYS */;
+INSERT INTO `Outlier` VALUES (1,1,50,200,'yellow'),(2,2,100,300,'orange'),(3,3,200,400,'red');
+/*!40000 ALTER TABLE `Outlier` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Platform`
+--
+
+DROP TABLE IF EXISTS `Platform`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Platform` (
+  `platformID` int(11) NOT NULL AUTO_INCREMENT,
+  `organizationID` int(10) unsigned DEFAULT NULL,
+  `name` varchar(150) NOT NULL,
+  `reportDisplayName` varchar(150) DEFAULT NULL,
+  `reportDropDownInd` tinyint(1) unsigned DEFAULT '0',
+  PRIMARY KEY (`platformID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Platform`
+--
+
+LOCK TABLES `Platform` WRITE;
+/*!40000 ALTER TABLE `Platform` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Platform` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `PlatformNote`
+--
+
+DROP TABLE IF EXISTS `PlatformNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PlatformNote` (
+  `platformNoteID` int(11) NOT NULL AUTO_INCREMENT,
+  `platformID` int(11) DEFAULT NULL,
+  `startYear` int(4) DEFAULT NULL,
+  `endYear` int(4) DEFAULT NULL,
+  `counterCompliantInd` tinyint(1) unsigned DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`platformNoteID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `PlatformNote`
+--
+
+LOCK TABLES `PlatformNote` WRITE;
+/*!40000 ALTER TABLE `PlatformNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `PlatformNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Privilege`
+--
+
+DROP TABLE IF EXISTS `Privilege`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Privilege` (
+  `privilegeID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `shortName` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`privilegeID`) USING BTREE
+) ENGINE=MyISAM AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Privilege`
+--
+
+LOCK TABLES `Privilege` WRITE;
+/*!40000 ALTER TABLE `Privilege` DISABLE KEYS */;
+INSERT INTO `Privilege` VALUES (1,'admin'),(2,'add/edit');
+/*!40000 ALTER TABLE `Privilege` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Publisher`
+--
+
+DROP TABLE IF EXISTS `Publisher`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Publisher` (
+  `publisherID` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(150) NOT NULL,
+  PRIMARY KEY (`publisherID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Publisher`
+--
+
+LOCK TABLES `Publisher` WRITE;
+/*!40000 ALTER TABLE `Publisher` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Publisher` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `PublisherPlatform`
+--
+
+DROP TABLE IF EXISTS `PublisherPlatform`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PublisherPlatform` (
+  `publisherPlatformID` int(11) NOT NULL AUTO_INCREMENT,
+  `publisherID` int(11) DEFAULT NULL,
+  `platformID` int(11) DEFAULT NULL,
+  `organizationID` int(10) unsigned DEFAULT NULL,
+  `reportDisplayName` varchar(150) NOT NULL,
+  `reportDropDownInd` tinyint(1) unsigned NOT NULL,
+  PRIMARY KEY (`publisherPlatformID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `PublisherPlatform`
+--
+
+LOCK TABLES `PublisherPlatform` WRITE;
+/*!40000 ALTER TABLE `PublisherPlatform` DISABLE KEYS */;
+/*!40000 ALTER TABLE `PublisherPlatform` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `PublisherPlatformNote`
+--
+
+DROP TABLE IF EXISTS `PublisherPlatformNote`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PublisherPlatformNote` (
+  `publisherPlatformNoteID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `publisherPlatformID` int(10) unsigned NOT NULL,
+  `startYear` int(4) unsigned DEFAULT NULL,
+  `endYear` int(4) unsigned DEFAULT NULL,
+  `noteText` text,
+  PRIMARY KEY (`publisherPlatformNoteID`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `PublisherPlatformNote`
+--
+
+LOCK TABLES `PublisherPlatformNote` WRITE;
+/*!40000 ALTER TABLE `PublisherPlatformNote` DISABLE KEYS */;
+/*!40000 ALTER TABLE `PublisherPlatformNote` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `SushiService`
+--
+
+DROP TABLE IF EXISTS `SushiService`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SushiService` (
+  `sushiServiceID` int(11) NOT NULL AUTO_INCREMENT,
+  `platformID` int(11) DEFAULT NULL,
+  `publisherPlatformID` int(11) DEFAULT NULL,
+  `serviceURL` varchar(300) DEFAULT NULL,
+  `wsdlURL` varchar(300) DEFAULT NULL,
+  `requestorID` varchar(300) DEFAULT NULL,
+  `customerID` varchar(300) DEFAULT NULL,
+  `login` varchar(300) DEFAULT NULL,
+  `password` varchar(300) DEFAULT NULL,
+  `security` varchar(300) DEFAULT NULL,
+  `serviceDayOfMonth` varchar(300) DEFAULT NULL,
+  `noteText` varchar(300) DEFAULT NULL,
+  `releaseNumber` varchar(45) DEFAULT NULL,
+  `reportLayouts` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`sushiServiceID`),
+  KEY `Index_publisherPlatformID` (`publisherPlatformID`),
+  KEY `Index_platformID` (`platformID`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `SushiService`
+--
+
+LOCK TABLES `SushiService` WRITE;
+/*!40000 ALTER TABLE `SushiService` DISABLE KEYS */;
+/*!40000 ALTER TABLE `SushiService` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Title`
+--
+
+DROP TABLE IF EXISTS `Title`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Title` (
+  `titleID` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(100) DEFAULT NULL,
+  `resourceType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`titleID`),
+  KEY `Index_title` (`title`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Title`
+--
+
+LOCK TABLES `Title` WRITE;
+/*!40000 ALTER TABLE `Title` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Title` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `TitleIdentifier`
+--
+
+DROP TABLE IF EXISTS `TitleIdentifier`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `TitleIdentifier` (
+  `titleIdentifierID` int(11) NOT NULL AUTO_INCREMENT,
+  `titleID` int(11) DEFAULT NULL,
+  `identifier` varchar(25) DEFAULT NULL,
+  `identifierType` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`titleIdentifierID`),
+  KEY `Index_titleID` (`titleID`),
+  KEY `Index_issn` (`identifier`) USING BTREE,
+  KEY `Index_ISSNType` (`identifierType`) USING BTREE
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `TitleIdentifier`
+--
+
+LOCK TABLES `TitleIdentifier` WRITE;
+/*!40000 ALTER TABLE `TitleIdentifier` DISABLE KEYS */;
+/*!40000 ALTER TABLE `TitleIdentifier` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `User` (
+  `loginID` varchar(50) NOT NULL,
+  `lastName` varchar(45) DEFAULT NULL,
+  `firstName` varchar(45) DEFAULT NULL,
+  `privilegeID` int(10) unsigned NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `User`
+--
+
+LOCK TABLES `User` WRITE;
+/*!40000 ALTER TABLE `User` DISABLE KEYS */;
+INSERT INTO `User` VALUES ('coral_test',NULL,NULL,1);
+/*!40000 ALTER TABLE `User` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Version`
+--
+
+DROP TABLE IF EXISTS `Version`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Version` (
+  `version` varchar(10) NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Version`
+--
+
+LOCK TABLES `Version` WRITE;
+/*!40000 ALTER TABLE `Version` DISABLE KEYS */;
+INSERT INTO `Version` VALUES ('1.2');
+/*!40000 ALTER TABLE `Version` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `YearlyUsageSummary`
+--
+
+DROP TABLE IF EXISTS `YearlyUsageSummary`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `YearlyUsageSummary` (
+  `yearlyUsageSummaryID` int(11) NOT NULL AUTO_INCREMENT,
+  `titleID` int(11) NOT NULL,
+  `publisherPlatformID` int(11) NOT NULL,
+  `year` int(4) DEFAULT NULL,
+  `archiveInd` tinyint(1) DEFAULT NULL,
+  `totalCount` int(11) DEFAULT NULL,
+  `ytdHTMLCount` int(11) DEFAULT NULL,
+  `ytdPDFCount` int(11) DEFAULT NULL,
+  `overrideTotalCount` int(10) unsigned DEFAULT NULL,
+  `overrideHTMLCount` int(10) unsigned DEFAULT NULL,
+  `overridePDFCount` int(10) unsigned DEFAULT NULL,
+  `mergeInd` tinyint(1) unsigned DEFAULT '0',
+  `activityType` varchar(45) DEFAULT NULL,
+  `sectionType` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`yearlyUsageSummaryID`) USING BTREE,
+  KEY `Index_titleID` (`titleID`),
+  KEY `Index_publisherPlatformID` (`publisherPlatformID`),
+  KEY `Index_year` (`year`),
+  KEY `Index_TPPYA` (`titleID`,`publisherPlatformID`,`year`,`archiveInd`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `YearlyUsageSummary`
+--
+
+LOCK TABLES `YearlyUsageSummary` WRITE;
+/*!40000 ALTER TABLE `YearlyUsageSummary` DISABLE KEYS */;
+/*!40000 ALTER TABLE `YearlyUsageSummary` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2016-09-09 17:54:41

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
+    use _generated\AcceptanceTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class FunctionalTester extends \Codeception\Actor
+{
+    use _generated\FunctionalTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Acceptance extends \Codeception\Module
+{
+
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -4,7 +4,49 @@ namespace Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Acceptance extends \Codeception\Module
-{
+class Acceptance extends \Codeception\Module {
 
+	public function _beforeSuite($settings = []) {
+		$I = $this->getModule("WebDriver");
+		$this->assertThatItsNot(getenv("CORAL_LOGIN"), false,
+								"CORAL_LOGIN not in environment variables");
+		$this->assertThatItsNot(getenv("CORAL_PASS"), false,
+								"CORAL_PASS not in environment variables");
+
+		$I->amOnPage("/auth/");
+		codecept_debug("I ensure that the language is English"); // not matter the system's locale
+		$I->selectOption("lang", "Français"); // See issue #103 for why we must switch twice.
+		$I->selectOption("lang", "English");
+
+		codecept_debug("I login");
+		$I->fillField("loginID", getenv("CORAL_LOGIN"));
+		$I->fillField("password", getenv("CORAL_PASS"));
+		$I->click("#loginbutton");
+		$I->see("Resources"); // login success
+		$I->see("Licensing");
+	}
+
+	function willAcceptTheNextConfirmBox() {
+		$acceptNextConfirmBox = <<<JS
+var realConfirm = window.confirm;
+window.confirm = function() {
+	window.confirm = realConfirm;
+	return true;
+};
+JS;
+		$this->getModule("WebDriver")->executeJS($acceptNextConfirmBox);
+	}
+
+	function waitForPageToBeReady() {
+		$javaScriptExpression = <<<JS
+// First: check that all events finished: onClick, onChange, onLoad, Ajax and maybe more.
+// Flag is stored in window because this isn't evaluated in the global scope so 'var myVar' woudn't work
+setTimeout(function() { window.allEventsFinished = true;}, 0);
+return window.allEventsFinished === true &&
+// Check that page + resources loaded. Which isn't covered by previous check.
+// Maybe it's already covered by Codeception.
+document.readyState === 'complete';
+JS;
+		$this->getModule("WebDriver")->waitForJS($javaScriptExpression, 5);
+	}
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -6,25 +6,26 @@ namespace Helper;
 
 class Acceptance extends \Codeception\Module {
 
-	public function _beforeSuite($settings = []) {
+    public function _beforeSuite($settings = array()) {
+		$this->switchToTestEnvironement();
+    }
+
+
+    public function _afterSuite($settings = array()) {
+		$this->switchBackToProdEnvironement();
+    }
+
+
+    public function _before(\Codeception\TestInterface $test) {
+		$this->resetTestDatabase();
 		$I = $this->getModule("WebDriver");
-		$this->assertThatItsNot(getenv("CORAL_LOGIN"), false,
-								"CORAL_LOGIN not in environment variables");
-		$this->assertThatItsNot(getenv("CORAL_PASS"), false,
-								"CORAL_PASS not in environment variables");
+		$I->amOnPage("/");
 
-		$I->amOnPage("/auth/");
-		codecept_debug("I ensure that the language is English"); // not matter the system's locale
-		$I->selectOption("lang", "Français"); // See issue #103 for why we must switch twice.
-		$I->selectOption("lang", "English");
-
-		codecept_debug("I login");
-		$I->fillField("loginID", getenv("CORAL_LOGIN"));
-		$I->fillField("password", getenv("CORAL_PASS"));
-		$I->click("#loginbutton");
-		$I->see("Resources"); // login success
-		$I->see("Licensing");
+		$this->setCookieWithWorkaround("lang", "en_US");
+		$this->setCookieWithWorkaround("CORALLoginID", "coral_test");
+		$this->setCookieWithWorkaround("CORALSessionID", "bNWUrFmjzDtoyxXSyxlwLMROC5W5LwvnAH7sMkRBnBqcyDum1VZCiqRlmngyaRbbYZJl9anncTFQX03PMSSu9jWlN2ZoJ1FiQPJQ");
 	}
+
 
 	function willAcceptTheNextConfirmBox() {
 		$acceptNextConfirmBox = <<<JS
@@ -37,16 +38,59 @@ JS;
 		$this->getModule("WebDriver")->executeJS($acceptNextConfirmBox);
 	}
 
+
 	function waitForPageToBeReady() {
 		$javaScriptExpression = <<<JS
 // First: check that all events finished: onClick, onChange, onLoad, Ajax and maybe more.
 // Flag is stored in window because this isn't evaluated in the global scope so 'var myVar' woudn't work
 setTimeout(function() { window.allEventsFinished = true;}, 0);
 return window.allEventsFinished === true &&
+
+// no active Ajax request
+$.active == 0 &&
+
 // Check that page + resources loaded. Which isn't covered by previous check.
 // Maybe it's already covered by Codeception.
 document.readyState === 'complete';
 JS;
 		$this->getModule("WebDriver")->waitForJS($javaScriptExpression, 5);
 	}
+
+
+	/**
+	 * Wrapper for setCookie() (without additional params) that allows to
+	 * circumvent this issue:
+	 * https://github.com/Codeception/Codeception/issues/2900#issuecomment-234702552
+	 */
+	function setCookieWithWorkaround($name, $value) {
+		$I = $this->getModule("WebDriver");
+		try {
+			$I->setCookie($name, $value);
+		} catch (\Facebook\WebDriver\Exception\UnableToSetCookieException $e) {}
+	}
+
+
+	function resetTestDatabase() {
+		codecept_debug("resetting the test database: it may take from 7 to 20 seconds as there is a lot of data");
+		$user = "coral_test";
+		$passphrase = "coral_test";
+		$db = new \PDO("mysql:host=localhost", $user, $passphrase);
+		$sql = file_get_contents("tests/_data/test_database.sql");
+		$qr = $db->exec($sql);
+	}
+
+
+	public function switchToTestEnvironement() {
+		$config = new \Config_Lite("admin/configuration.ini");
+		$config->set("settings", "environment", "test");
+		$config->save();
+	}
+
+
+	public function switchBackToProdEnvironement() {
+		$config = new \Config_Lite("admin/configuration.ini");
+		$config->set("settings", "environment", "prod");
+		$config->save();
+	}
+
 }

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Functional extends \Codeception\Module
+{
+
+}

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Unit extends \Codeception\Module
+{
+
+}

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -1,0 +1,12 @@
+# Codeception Test Suite Configuration
+#
+# Suite for acceptance tests.
+# Perform tests in browser using the WebDriver or PhpBrowser.
+# If you need both WebDriver and PHPBrowser tests - create a separate suite.
+
+class_name: AcceptanceTester
+modules:
+    enabled:
+        - PhpBrowser:
+            url: http://localhost:8000
+        - \Helper\Acceptance

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -7,6 +7,8 @@
 class_name: AcceptanceTester
 modules:
     enabled:
-        - PhpBrowser:
-            url: http://localhost:8000
+        - WebDriver:
+            url: %BASE_URL%
+            browser: phantomjs
+            window_size: 1280x600
         - \Helper\Acceptance

--- a/tests/acceptance/LoginCept.php
+++ b/tests/acceptance/LoginCept.php
@@ -1,0 +1,13 @@
+<?php
+$I = new AcceptanceTester($scenario);
+$I->wantTo("ensure that login works");
+
+$I->amOnPage("/auth/");
+
+$I->fillField("loginID", "coral_test");
+$I->fillField("password", "coral_test");
+$I->click("#loginbutton");
+
+// login success
+$I->see("Resources");
+$I->see("Licensing");

--- a/tests/acceptance/ResourcesCept.php
+++ b/tests/acceptance/ResourcesCept.php
@@ -5,6 +5,7 @@ $I->wantTo("ensure that I can create/delete a resource and see it in the list");
 // Resources creation
 $I->amOnPage("/resources/");
 $I->click("New Resource");
+$I->waitForPageToBeReady(); // Ensure that the modal form loaded
 $I->fillField("#titleText", "test resource");
 $I->click(".submit-button");
 // we are redirected to the resource details page
@@ -17,10 +18,8 @@ $I->click("test resource");
 
 // delete resource
 $I->willAcceptTheNextConfirmBox();
-// $I->waitForPageToBeReady(); // Ensure that the buttons have loaded
 $I->click("remove resource"); // button title/name
 $I->waitForText("records per page"); // Ensure that the list has loaded by Ajax.
 // So the next check can't do a false positive (classic trap when asserting that
 // something is not here).
-$I->makeScreenshot("example_screenshot"); // will be saved in ./tests/_output/debug/example_screenshot.png
 $I->dontSee("test resource");

--- a/tests/acceptance/ResourcesCept.php
+++ b/tests/acceptance/ResourcesCept.php
@@ -1,0 +1,26 @@
+<?php
+$I = new AcceptanceTester($scenario);
+$I->wantTo("ensure that I can create/delete a resource and see it in the list");
+
+// Resources creation
+$I->amOnPage("/resources/");
+$I->click("New Resource");
+$I->fillField("#titleText", "test resource");
+$I->click(".submit-button");
+// we are redirected to the resource details page
+$I->waitForText("Edit Product Details", 5);  // ensures we are on the issue page
+
+// find resource in list an go to it's page
+$I->amOnPage("/resources/");
+$I->waitForPageToBeReady(); // Ensure that the list has loaded by Ajax.
+$I->click("test resource");
+
+// delete resource
+$I->willAcceptTheNextConfirmBox();
+// $I->waitForPageToBeReady(); // Ensure that the buttons have loaded
+$I->click("remove resource"); // button title/name
+$I->waitForText("records per page"); // Ensure that the list has loaded by Ajax.
+// So the next check can't do a false positive (classic trap when asserting that
+// something is not here).
+$I->makeScreenshot("example_screenshot"); // will be saved in ./tests/_output/debug/example_screenshot.png
+$I->dontSee("test resource");

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests

--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -1,0 +1,11 @@
+# Codeception Test Suite Configuration
+#
+# Suite for functional (integration) tests
+# Emulate web requests and make application process them
+# Include one of framework modules (Symfony2, Yii2, Laravel5) to use it
+
+class_name: FunctionalTester
+modules:
+    enabled:
+        # add framework module here
+        - \Helper\Functional

--- a/tests/functional/_bootstrap.php
+++ b/tests/functional/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit (internal) tests.
+
+class_name: UnitTester
+modules:
+    enabled:
+        - Asserts
+        - \Helper\Unit

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
This PR supersedes #115.

Follow [TEST.md](https://github.com/tuxayo/Coral/blob/isolate-db-in-tests/TESTS.md) to try it.

It adds:
### A separated database for tests
Before each test, it will load a dump of a clean install with [few things already set up.](https://github.com/tuxayo/Coral/blob/isolate-db-in-tests/tests/_data/test_database.sql#L10)
Which will avoid issues of a test leaving garbage that will disturb latter tests.
Test don't need anymore to clean themselves.
Your existing data won't interfere.

### The login is moved to it's own test
Which allowed to fix other issues that would immediately arise when another test would have been added.