### PR TITLE
Issue#123: From Email is incorrect

### DIFF
--- a/resources/admin/classes/common/Email.php
+++ b/resources/admin/classes/common/Email.php
@@ -34,10 +34,22 @@ class Email extends Object {
 	protected $subject;
 	protected $message;
 	protected $headers = array();
-
-	protected $from = "CORAL Resources";
 	protected $replyTo;
 
+    protected function guessFrom() {
+		$config = new Configuration();
+
+        if ($config->settings->emailFrom)
+            return $config->settings->emailFrom;
+
+        if (array_key_exists('SERVER_NAME', $_SERVER) && $_SERVER['SERVER_NAME'])
+            return 'no-reply@' . $_SERVER['SERVER_NAME'];
+
+        if (array_key_exists('HTTP_HOST', $_SERVER) && $_SERVER['HTTP_HOST'])
+            return 'no-reply@' . $_SERVER['HTTP_HOST'];
+
+        return 'no-reply@' . exec('hostname -f');
+    }
 
 	protected function nameIsBasic($name) {
 		return preg_match('/^(to)|(subject)|(message)$/', $name);
@@ -50,7 +62,7 @@ class Email extends Object {
 			$output .= $header->text();
 		}
 		//append from and reply to
-		$output .= "From: " . $this->from . "\r\n";
+		$output .= "From: " . $this->guessFrom() . "\r\n";
 		$output .= "Reply-To: " . $this->replyTo . "\r\n";
 		$output .= "Content-Type: text/plain; charset=UTF-8" . "\r\n";
 

--- a/resources/admin/configuration_sample.ini
+++ b/resources/admin/configuration_sample.ini
@@ -17,6 +17,7 @@ testMode=N
 testModeEmailAddress=
 defaultsort=
 importISBNDedupingColumns="ISSN,ISBN"
+emailFrom=
 
 [database]
 type = "mysql"


### PR DESCRIPTION
This patch allows the Email class to try to find a correct from for sending emails, in this order:
- Is there a emailFrom field in the config file?
- Is $_SERVER['SERVER_NAME'] defined?
- Is $_SERVER['HTTP_HOST'] defined?
- use system hostname
