### PR TITLE
Fixing poorly formatted NULL acquisitions dates

### DIFF
--- a/resources/ajax_processing/submitAcquisitions.php
+++ b/resources/ajax_processing/submitAcquisitions.php
@@ -6,14 +6,14 @@
 		if ((isset($_POST['currentStartDate'])) && ($_POST['currentStartDate'] != '')){
 			$resource->currentStartDate = date("Y-m-d", strtotime($_POST['currentStartDate']));
 		}else{
-			$resource->currentStartDate= 'null';
+			$resource->currentStartDate= NULL;
 		}
 
 		//first set current end Date for proper saving
 		if ((isset($_POST['currentEndDate'])) && ($_POST['currentEndDate'] != '')){
 			$resource->currentEndDate = date("Y-m-d", strtotime($_POST['currentEndDate']));
 		}else{
-			$resource->currentEndDate= 'null';
+			$resource->currentEndDate= NULL;
 		}
 
 		$resource->acquisitionTypeID 				= $_POST['acquisitionTypeID'];


### PR DESCRIPTION
The acquisition currentStartDate and currentEndDate were being passed `'null'` which mysql normally rejects as incorrect SQL for a `DATE` field. All the other `NULL` values being passed into the update query were coming in correctly as `NULL`, so I changed this file to match which fixed our database error.