### PR TITLE
Ridding "Notice: Undefined index:"

### DIFF
--- a/resources/admin/classes/common/Utility.php
+++ b/resources/admin/classes/common/Utility.php
@@ -68,7 +68,7 @@ class Utility {
 	//returns page URL up to /coral/
 	public function getCORALURL(){
 		$pageURL = 'http';
-		if ($_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
+		if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
 		$pageURL .= "://";
 		if ($_SERVER["SERVER_PORT"] != "80") {
 		  $pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"];


### PR DESCRIPTION
I repeatedly got the error "Notice: Undefined index: HTTPS in C:\xampp\htdocs\coral\resources\admin\classes\common\Utility.php".  

I should note that regardless of what I use for the URL's prefix (www, http:, https, etc), it always removes it.  so **www.mycoral.com** becomes **mycoral.com**.