### PR TITLE
Fix duplicate Parent bug in updateProduct

### DIFF
--- a/resources/ajax_forms/getUpdateProductForm.php
+++ b/resources/ajax_forms/getUpdateProductForm.php
@@ -120,7 +120,7 @@
 
            <span id="newParent">
            <div class="oneParent">
-           <input type='text' class='parentResource parentResource_new' name='parentResourceName' value='' style='width:140px;' class='changeInput'  /><input type='hidden' class='parentResource parentResource_new' name='parentResourceID' value='' /><span id='span_error_parentResourceName' class='smallDarkRedText'></span>
+           <input type='text' class='parentResource parentResource_new' name='parentResourceName' value='' style='width:140px;' class='changeInput'  /><input type='hidden' class='parentResource parentResource_new' name='parentResourceNewID' value='' /><span id='span_error_parentResourceName' class='smallDarkRedText'></span>
            <a href='#'><input class='addParent add-button' title='<?php echo _("add Parent Resource");?>' type='button' value='<?php echo _("Add");?>'/></a><br />
           </div>
            </span>

--- a/resources/js/forms/resourceUpdateForm.js
+++ b/resources/js/forms/resourceUpdateForm.js
@@ -271,7 +271,7 @@ $(function(){
 
 $(".addParent").live('click', function() {
 
-    var parentID = $("#newParent .oneParent input[name='parentResourceID']'").val();
+    var parentID = $("#newParent .oneParent input[name='parentResourceNewID']'").val();
     var parentName = $("#newParent .oneParent input[name='parentResourceName']'").val();
 
     if (parentName == '') {
@@ -284,6 +284,7 @@ $(".addParent").live('click', function() {
     }
 
     var newParentValue = $('.parentResource_new').clone();
+    newParentValue.filter("input[name='parentResourceNewID']").attr("name","parentResourceID");
     newParentValue.removeClass('parentResource_new').css({"width": "180px"});
     newParentValue.attr('disabled', 'disabled');
     var newParentStr = "<div class='oneParent'></div>";


### PR DESCRIPTION
Resolves #148 

This is a quick fix to resolve the bug.

A more thorough refactor of the javascript and HTML is needed, since it seems to be halfway between an original, single parent version, and the current multiple add version. 

This makes it difficult to debug, and performance could be improved with more precise jQuery selectors and HTML dedicated to adding multiple parents in one edit.