### PR TITLE
Organizations install patch

### DIFF
--- a/organizations/install/organizations.php
+++ b/organizations/install/organizations.php
@@ -13,7 +13,7 @@ function register_organizations_provider()
 			switch ($version) {
 				case Installer::VERSION_STRING_INSTALL:
 					return [
-						"dependencies_array" => ["have_database_access", "modules_to_use", "have_default_coral_admin_user", "have_default_db_user", "some_kind_of_auth"],
+						"dependencies_array" => ["have_read_write_access_to_config", "have_database_access", "modules_to_use", "have_default_coral_admin_user", "have_default_db_user", "some_kind_of_auth"],
 						"sharedInfo" => [
 							"database" => [
 								"title" => _("Organizations Database"),


### PR DESCRIPTION
Added the missing install dependency have_read_write_access_to_config to fix the bug where the organizations module did not get its configuration file written when installing 2.0 from scratch.