### PR TITLE
Removes "Undefinied index.." if no prefix

### DIFF
--- a/licensing/admin/classes/common/Utility.php
+++ b/licensing/admin/classes/common/Utility.php
@@ -58,7 +58,7 @@ class Utility {
 	//returns page URL up to /coral/
 	public function getCORALURL(){
 		$pageURL = 'http';
-		if ($_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
+		if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
 		$pageURL .= "://";
 		if ($_SERVER["SERVER_PORT"] != "80") {
 		  $pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"];


### PR DESCRIPTION
If there's no http / https prefix, the isset() keeps a warning from being thrown.

Previously #161 on master branch, reopening on new development branch.