### PR TITLE
If resourceISBNOrISSN is missing, don't display notice

### DIFF
--- a/resources/index.php
+++ b/resources/index.php
@@ -75,7 +75,7 @@ include 'templates/header.php';
 	<tr>
 	<td class='searchRow'><label for='searchResourceISBNOrISSN'><b><?php echo _("ISBN/ISSN");?></b></label>
 	<br />
-	<?php echo Html::text_search_field_tag('resourceISBNOrISSN', $search['resourceISBNOrISSN']); ?>
+	<?php echo Html::text_search_field_tag('resourceISBNOrISSN', isset($search['resourceISBNOrISSN']) ? $search['resourceISBNOrISSN'] : ''); ?>
 	<br />
 	<div id='div_searchISBNOrISSN' style='<?php if (!$search['resourceISBNOrISSN']) echo "display:none;"; ?>margin-left:123px;'><input type='button' name='btn_searchResourceISBNOrISSN' value='<?php echo _("go!");?>' class='searchButton' /></div>
 	</td>


### PR DESCRIPTION
If there is nothing in the resourceISBNOrISSN variable, don't display a "Notice: Undefined..." warning.