### PR TITLE
Fix "Get Statistics" button

### DIFF
--- a/resources/ajax_htmldata/getRightPanel.php
+++ b/resources/ajax_htmldata/getRightPanel.php
@@ -113,7 +113,7 @@
 				<?php
 			echo "<form method='post' action='/reports/report.php' target='_blank'>";
 			echo "<input type='hidden' name='reportID' value='1'>";
-			echo "<input type='hidden' name='prm_21' value='".$resource->titleText."'>";
+			echo "<input type='hidden' name='prm_3' value='".$resource->titleText."'>";
 			echo "<input type='submit' value='"._("Get Statistics")."'>";
 			echo "</form>";
 							?>


### PR DESCRIPTION
The newest version of the reports module added parameters to the database in a way that should prevent the changing form parameters that caused this button to break in the past.  prm_3 is now the title search parameter.