### PR TITLE
Fixed #179

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -2192,6 +2192,10 @@ a.showAccounts:before {
 		margin-right: 5px;
 }
 
+a.showAccounts {
+	text-transform: capitalize;
+}
+
 /*--- IE 11 Fix for Sidemenu Link Color ---*/
 
 .sidemenu span.link a {
@@ -2337,6 +2341,10 @@ a.showIssues:before {
     content: "\f071";
     font-size: 11px;
     margin-right: 5px;
+}
+
+a.showIssues {
+	text-transform: capitalize;
 }
 
 #issueTable img {


### PR DESCRIPTION
Fixed #179. a.showIssues and a.showAccounts were missing the relevant CSS to capitalize the first letter found in the other .show* classes