### PR TITLE
Iss178 workaround

### DIFF
--- a/resources/ajax_htmldata/getProductDetails.php
+++ b/resources/ajax_htmldata/getProductDetails.php
@@ -57,7 +57,7 @@
 
 
 		?>
-		<table class='linedFormTable' style='width:460px;'>
+		<table class='linedFormTable' style='word-wrap: break-word; width:460px;'>
 			<tr>
 				<th width="115"></th>
 				<th></th>
@@ -268,7 +268,7 @@
 			if ($resource->resourceURL) { ?>
 				<tr>
 				<td style='vertical-align:top;width:115px;'><?php echo _("Resource URL:");?></td>
-				<td style='width:345px;'><?php echo $resource->resourceURL; ?>&nbsp;&nbsp;<a href='<?php echo $resource->resourceURL; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt="<?php echo _("Visit Resource URL");?>" title="<?php echo _("Visit Resource URL");?>" style='vertical-align:top;'></a></td>
+				<td style='max-width:400px;'><?php echo $resource->resourceURL; ?>&nbsp;&nbsp;<a href='<?php echo $resource->resourceURL; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt="<?php echo _("Visit Resource URL");?>" title="<?php echo _("Visit Resource URL");?>" style='vertical-align:top;'></a></td>
 				</tr>
 			<?php
 			}


### PR DESCRIPTION
Workaround that resolves #178. Set the max-width property of the URL <td> and set the style of the table to break word on word-wrap. The URL overflows outside of the <td> element if word-wrap: break-word isn't set.

A more ideal solution would likely require significant changes to styling. With the table layout, heavy in-line styling usage, explicit widths (especially when child elements had larger widths than their parent), and CSS styles marked !important, it was difficult to find the root cause and provide an alternate solution to the issue.

We tried collapsing the helpful links box and displaying it when the user hovers over it, but it still covered content and buttons when the content made the table exceed a certain width (despite having a width explicitly set in in-line styling of the table element).  We also tried moving the right panel over below the left side panel, but this too proved difficult, especially because the side menu is created several times in the same document rather than being a single menu that uses JavaScript to load content into the main content div.

We tried the negative right margin workaround that @jeffnm came up with, but it turns out -115px isn't enough when the URL width exceeds a certain point.

The changes in this pull request should deal with the issue in the cases we tested, but it seems that a more elegant solution would need an overhaul to CSS.