### PR TITLE
fixing extra slash in getCoralPath

### DIFF
--- a/resources/admin/classes/common/Utility.php
+++ b/resources/admin/classes/common/Utility.php
@@ -59,7 +59,9 @@ class Utility {
 		$currentFile = $_SERVER["SCRIPT_NAME"];
 		$parts = Explode('/', $currentFile);
 		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
+			if ($parts[$i] != ''){
+				$pagePath .= $parts[$i] . '/';
+			}
 		}
 
 		return $pagePath;


### PR DESCRIPTION
Currently when $_SERVER["DOCUMENT_ROOT"] ends in a "/" and $_SERVER["SCRIPT_NAME"] starts with a slash, this function will return an invalid path.  I just added a check before it adds more slashes to the pagePath.