### PR TITLE
Add item to GROUP BY for new MySQL 5.7 default compatibility.

### DIFF
--- a/organizations/admin/classes/domain/Organization.php
+++ b/organizations/admin/classes/domain/Organization.php
@@ -639,7 +639,7 @@ class Organization extends DatabaseObject {
 		$alphArray = array();
 		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)) letter_count
 								FROM Organization O
-								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)
+								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM name),1,1), O.name
 								ORDER BY 1;");
 
 		while ($row = mysqli_fetch_assoc($result)){

--- a/organizations/admin/classes/domain/Organization.php
+++ b/organizations/admin/classes/domain/Organization.php
@@ -543,7 +543,7 @@ class Organization extends DatabaseObject {
 									LEFT JOIN ContactRoleProfile CRP ON C.contactID = CRP.contactID
 									LEFT JOIN ContactRole CR ON CR.contactRoleID = CRP.contactRoleID
 								" . $whereStatement . "
-								GROUP By O.organizationID
+								GROUP BY O.organizationID, OHP.parentOrganizationID
 								ORDER BY " . $orderBy . $limitStatement;
 
 

--- a/organizations/admin/classes/domain/Organization.php
+++ b/organizations/admin/classes/domain/Organization.php
@@ -639,7 +639,7 @@ class Organization extends DatabaseObject {
 		$alphArray = array();
 		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)) letter_count
 								FROM Organization O
-								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM name),1,1), O.name
+								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM name),1,1)
 								ORDER BY 1;");
 
 		while ($row = mysqli_fetch_assoc($result)){


### PR DESCRIPTION
PHP message: PHP Fatal error:  Uncaught Exception: There was a problem with the database: Expression #5 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'coral_organizations.OHP.parentOrganizationID’ which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by in /var/www/coral/organizations/admin/classes/common/DBService.php:39
Stack trace:
#0 /var/www/coral/organizations/admin/classes/common/DBService.php(71): DBService->checkForError()
#1 /var/www/coral/organizations/admin/classes/domain/Organization.php(550): DBService->processQuery('SELECT O.organi…', 'assoc’)
#2 /var/www/coral/organizations/ajax_htmldata.php(895): Organization->search(Array, ‘TRIM(LEADING ‘T…’, ‘’)
#3 {main}
  thrown in /var/www/coral/organizations/admin/classes/common/DBService.php on line 39

Issue #235 