### PR TITLE
Reuse existing MySQL connection

### DIFF
--- a/auth/admin/classes/common/DBService.php
+++ b/auth/admin/classes/common/DBService.php
@@ -1,8 +1,7 @@
 <?php
 /*
 **************************************************************************************************************************
-** CORAL Usage Statistics Reporting Module v. 1.0
-**
+** 
 ** Copyright (c) 2010 University of Notre Dame
 **
 ** This file is part of CORAL.
@@ -17,16 +16,18 @@
 */
 
 
+
 class DBService extends Object {
 
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;//used to hold current DB connection for reuse.
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
 		$this->config = new Configuration;
-		$this->connect();
+                $this->connect();
 	}
 
 	protected function dealloc() {
@@ -35,48 +36,48 @@ class DBService extends Object {
 	}
 
 	protected function checkForError() {
-		if ($this->error = mysqli_error($this->db)) {
+            $this->error = mysqli_error($this->db);
+		if ($this->error) {
 			throw new Exception(_("There was a problem with the database: ") . $this->error);
 		}
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
 		$databaseName = $this->config->database->name;
 		$this->db = mysqli_connect($host, $username, $password, $databaseName);
-		$this->checkForError();
-        $this->db->set_charset('utf8');
+                $this->checkForError();
+                mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+            } else {
+                $this->db=self::$currDBH;
+            }
 	}
 
 	protected function disconnect() {
-		//$this->db->close();
-	}
-
-	public function changeDB($databaseName) {
-		//$databaseName='coral_reporting_pprd';
-		$this->db->select_db($databaseName);
-		$this->checkForError();
+		//mysqli_close($this->db);
 	}
 
 	public function escapeString($value) {
-		return $this->db->escape_string($value);
+        return $this->db->real_escape_string($value);
 	}
 
 	public function getDatabase() {
 		return $this->db;
 	}
 
-    public function query($sql) {
+        public function query($sql) {
         $result = $this->db->query($sql);
         $this->checkForError();
         return $result;
-	}
+    }
 
 	public function processQuery($sql, $type = NULL) {
-    	//echo $sql. "<br />";
-		$result = $this->db->query($sql);
+    //echo $sql. "<br />";
+    		$result = mysqli_query($this->db, $sql);
 		$this->checkForError();
 		$data = array();
 
@@ -85,16 +86,16 @@ class DBService extends Object {
 			if ($type == 'assoc') {
 				$resultType = MYSQLI_ASSOC;
 			}
-			while ($row = $result->fetch_array($resultType)) {
-				if ($this->db->affected_rows > 1) {
+			while ($row = mysqli_fetch_array($result, $resultType)) {
+				if (mysqli_affected_rows($this->db) > 1) {
 					array_push($data, $row);
 				} else {
 					$data = $row;
 				}
 			}
-			$result->free();
+			mysqli_free_result($result);
 		} else if ($result) {
-			$data = $this->db->insert_id;
+			$data = mysqli_insert_id($this->db);
 		}
 
 		return $data;

--- a/licensing/admin/classes/common/DBService.php
+++ b/licensing/admin/classes/common/DBService.php
@@ -1,8 +1,7 @@
 <?php
 /*
 **************************************************************************************************************************
-** CORAL Licensing Module v. 1.0
-**
+** 
 ** Copyright (c) 2010 University of Notre Dame
 **
 ** This file is part of CORAL.
@@ -63,20 +62,22 @@ class DBService extends Object {
 	}
 
 	public function escapeString($value) {
-		return mysqli_real_escape_string($this->db, $value);
+        return $this->db->real_escape_string($value);
 	}
 
 	public function getDatabase() {
 		return $this->db;
 	}
 
+        public function query($sql) {
+        $result = $this->db->query($sql);
+        $this->checkForError();
+        return $result;
+    }
+
 	public function processQuery($sql, $type = NULL) {
     //echo $sql. "<br />";
-    $query_start = microtime(true);
-		$result = mysqli_query($this->db, $sql);
-		$query_end = microtime(true);
-		$this->log($sql, $query_end - $query_start);
-
+    		$result = mysqli_query($this->db, $sql);
 		$this->checkForError();
 		$data = array();
 
@@ -161,18 +162,6 @@ class DBService extends Object {
 		}
 		return $refs;
 	}
-
-	public function log($sql, $query_time) {
-	  $threshold = $this->config->database->logQueryThreshold;
-    if ($this->config->database->logQueries == "Y" && (!$threshold || $query_time >= $threshold)) {
-      $util = new Utility();
-      $log_path = $util->getModulePath()."/log";
-      $log_file = $log_path."/database.log";
-      $log_string = date("c")."\n".$_SERVER['REQUEST_URI']."\n".$sql."\nQuery completed in ".sprintf("%.3f", round($query_time, 3))." seconds";
-      error_log($log_string."\n\n", 3, $log_file);
-    }
-	}
-
 }
 
 ?>

--- a/licensing/admin/classes/common/DBService.php
+++ b/licensing/admin/classes/common/DBService.php
@@ -23,11 +23,12 @@ class DBService extends Object {
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;//used to hold current DB connection for reuse.
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
 		$this->config = new Configuration;
-		$this->connect();
+                $this->connect();
 	}
 
 	protected function dealloc() {
@@ -36,19 +37,25 @@ class DBService extends Object {
 	}
 
 	protected function checkForError() {
-		if ($this->error = mysqli_error($this->db)) {
+            $this->error = mysqli_error($this->db);
+		if ($this->error) {
 			throw new Exception(_("There was a problem with the database: ") . $this->error);
 		}
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
 		$databaseName = $this->config->database->name;
 		$this->db = mysqli_connect($host, $username, $password, $databaseName);
-		$this->checkForError();
+                $this->checkForError();
                 mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+            } else {
+                $this->db=self::$currDBH;
+            }
 	}
 
 	protected function disconnect() {

--- a/management/admin/classes/common/DBService.php
+++ b/management/admin/classes/common/DBService.php
@@ -23,6 +23,7 @@ class DBService extends Object {
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
@@ -42,6 +43,7 @@ class DBService extends Object {
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
@@ -52,8 +54,12 @@ class DBService extends Object {
 		$this->db->select_db($databaseName);
 		$this->db->set_charset('utf8');
 		$this->checkForError();
-	}
-
+                mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+	    } else {
+                $this->db=self::$currDBH;
+            }
+        }
 	protected function disconnect() {
 		//mysqli_close($this->db);
 	}

--- a/organizations/admin/classes/common/DBService.php
+++ b/organizations/admin/classes/common/DBService.php
@@ -22,6 +22,7 @@ class DBService extends Object {
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;//used to hold current DB connection for reuse.
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
@@ -41,16 +42,21 @@ class DBService extends Object {
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
 		$this->db = new mysqli($host, $username, $password);
-		$this->checkForError();
-        $this->db->set_charset('utf8');
-
+                $this->checkForError();
+                $this->db->set_charset('utf8');
 		$databaseName = $this->config->database->name;
 		$this->db->select_db($databaseName);
 		$this->checkForError();
+                mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+            } else {
+                $this->db=self::$currDBH;
+	   }
 	}
 
 	protected function disconnect() {

--- a/resources/admin/classes/common/DBService.php
+++ b/resources/admin/classes/common/DBService.php
@@ -22,6 +22,7 @@ class DBService extends Object {
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;//used to hold current DB connection for reuse.
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
@@ -41,17 +42,22 @@ class DBService extends Object {
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
 		$this->db = new mysqli($host, $username, $password);
-		$this->checkForError();
-        $this->db->set_charset('utf8');
-
-		$databaseName = $this->config->database->name;
-        $this->db->select_db($databaseName);
-		$this->checkForError();
-	}
+                $this->checkForError();
+                $this->db->set_charset('utf8');
+                $databaseName = $this->config->database->name;
+                $this->db->select_db($databaseName);
+                $this->checkForError();
+                mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+            } else {
+                $this->db=self::$currDBH;
+	    }
+        }
 
 	protected function disconnect() {
 		//mysqli_close($this->db);

--- a/usage/admin/classes/common/DBService.php
+++ b/usage/admin/classes/common/DBService.php
@@ -22,6 +22,7 @@ class DBService extends Object {
 	protected $db;
 	protected $config;
 	protected $error;
+        private static $currDBH;//used to hold current DB connection for reuse.
 
 	protected function init(NamedArguments $arguments) {
 		parent::init($arguments);
@@ -41,12 +42,18 @@ class DBService extends Object {
 	}
 
 	protected function connect() {
+            if(empty(self::$currDBH)){
 		$host = $this->config->database->host;
 		$username = $this->config->database->username;
 		$password = $this->config->database->password;
 		$databaseName = $this->config->database->name;
 		$this->db = mysqli_connect($host, $username, $password, $databaseName);
 		$this->checkForError();
+                mysqli_set_charset($this->db, 'utf8');
+                self::$currDBH=$this->db;
+            } else {
+                $this->db=self::$currDBH;
+            }
 	}
 
 	protected function disconnect() {

--- a/usage/admin/classes/common/DBService.php
+++ b/usage/admin/classes/common/DBService.php
@@ -1,8 +1,7 @@
 <?php
 /*
 **************************************************************************************************************************
-** CORAL Licensing Module v. 1.0
-**
+** 
 ** Copyright (c) 2010 University of Notre Dame
 **
 ** This file is part of CORAL.
@@ -63,20 +62,22 @@ class DBService extends Object {
 	}
 
 	public function escapeString($value) {
-		return mysqli_real_escape_string($this->db, $value);
+        return $this->db->real_escape_string($value);
 	}
 
 	public function getDatabase() {
 		return $this->db;
 	}
 
+        public function query($sql) {
+        $result = $this->db->query($sql);
+        $this->checkForError();
+        return $result;
+    }
+
 	public function processQuery($sql, $type = NULL) {
     //echo $sql. "<br />";
-    $query_start = microtime(true);
-		$result = mysqli_query($this->db, $sql);
-		$query_end = microtime(true);
-		$this->log($sql, $query_end - $query_start);
-
+    		$result = mysqli_query($this->db, $sql);
 		$this->checkForError();
 		$data = array();
 
@@ -161,18 +162,6 @@ class DBService extends Object {
 		}
 		return $refs;
 	}
-
-	public function log($sql, $query_time) {
-	  $threshold = $this->config->database->logQueryThreshold;
-    if ($this->config->database->logQueries == "Y" && (!$threshold || $query_time >= $threshold)) {
-      $util = new Utility();
-      $log_path = $util->getModulePath()."/log";
-      $log_file = $log_path."/database.log";
-      $log_string = date("c")."\n".$_SERVER['REQUEST_URI']."\n".$sql."\nQuery completed in ".sprintf("%.3f", round($query_time, 3))." seconds";
-      error_log($log_string."\n\n", 3, $log_file);
-    }
-	}
-
 }
 
 ?>


### PR DESCRIPTION
Update DBService.php of all modules except the Report one to reuse existing MySQL database connection.  A new private static  property called $currDBH is introduced into the DBService class. This property is used to store existing database connection.  In order to keep number of changes small, the original instance property $db is kept and its value is set with the value of $currDBH whenever existing connection is available.  Without this fix, Coral  opens as many database connections as number of child records  until request for new connection is silently rejected and sees no records returned at all when processing child records (e.g., License record). 