### PR TITLE
Make Coral work with Shibboleth

### DIFF
--- a/licensing/admin/configuration_sample.ini
+++ b/licensing/admin/configuration_sample.ini
@@ -9,6 +9,7 @@ resourcesDatabaseName=
 managementModule=Y
 useTermsToolFunctionality=N
 remoteAuthVariableName="_SERVER['REMOTE_USER']"
+#idpLogout="https://idp.youruniversity/idp/profile/Logout"
 
 [database]
 type = "mysql"

--- a/licensing/templates/header.php
+++ b/licensing/templates/header.php
@@ -122,6 +122,8 @@ $coralURL = $util->getCORALURL();
                 </span><br />
 
             <?php if($config->settings->authModule == 'Y'){ echo "<a href='" . $coralURL . "auth/?logout' id='logout'>" . _("logout") . "</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+            <?php if($config->settings->authModule == 'N'){ echo "<a href='https://".$_SERVER["SERVER_NAME"]."/Shibboleth.sso/Logout?return=".$config->settings->idpLogout."' id='logout' title='" . _("logout")."'>"._("logout")."</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+
 
                 <span id="setLanguage">
                     <select name="lang" id="lang" class="dropDownLang">

--- a/management/admin/configuration_sample.ini
+++ b/management/admin/configuration_sample.ini
@@ -14,6 +14,7 @@ resourcesDatabaseName=
 licensingModule=N
 useTermsToolFunctionality=N
 remoteAuthVariableName="_SERVER['REMOTE_USER']"
+#idpLogout="https://idp.youruniversity/idp/profile/Logout"
 
 [database]
 type = "mysql"

--- a/management/templates/header.php
+++ b/management/templates/header.php
@@ -119,6 +119,8 @@ $coralURL = $util->getCORALURL();
                 </span><br />
 
             <?php if($config->settings->authModule == 'Y'){ echo "<a href='" . $coralURL . "auth/?logout' id='logout'>" . _("logout") . "</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+            <?php if($config->settings->authModule == 'N'){ echo "<a href='https://".$_SERVER["SERVER_NAME"]."/Shibboleth.sso/Logout?return=".$config->settings->idpLogout."' id='logout' title='" . _("logout")."'>"._("logout")."</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+
 
                 <span id="setLanguage">
             		<select name="lang" id="lang" class="dropDownLang">

--- a/organizations/admin/configuration_sample.ini
+++ b/organizations/admin/configuration_sample.ini
@@ -9,6 +9,7 @@ resourcesIssues=N
 authModule=N
 authDatabaseName=
 remoteAuthVariableName="_SERVER['REMOTE_USER']"
+#idpLogout="https://idp.youruniversity/idp/profile/Logout"
 
 [database]
 type = "mysql"

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -112,6 +112,7 @@ $coralURL = $util->getCORALURL();
                 </span><br />
 
             <?php if($config->settings->authModule == 'Y'){ echo "<a href='" . $coralURL . "auth/?logout' id='logout'>" . _("logout") . "</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+             <?php if($config->settings->authModule == 'N'){ echo "<a href='https://".$_SERVER["SERVER_NAME"]."/Shibboleth.sso/Logout?return=".$config->settings->idpLogout."' id='logout' title='" . _("logout")."'>"._("logout")."</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
 
                 <span id="setLanguage">
                     <select name="lang" id="lang" class="dropDownLang">

--- a/resources/admin/configuration_sample.ini
+++ b/resources/admin/configuration_sample.ini
@@ -9,6 +9,7 @@ enhancedCostHistory=N
 authModule=N
 authDatabaseName=
 remoteAuthVariableName="_SERVER['REMOTE_USER']"
+#idpLogout="https://idp.youruniversity/idp/profile/Logout"
 defaultCurrency="USD"
 enableAlerts=
 catalogURL=

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -111,6 +111,7 @@ $coralURL = $util->getCORALURL();
                 </span><br />
 
             <?php if($config->settings->authModule == 'Y'){ echo "<a href='" . $coralURL . "auth/?logout' id='logout' title='" . _("logout") . "'>" . _("logout") . "</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+            <?php if($config->settings->authModule == 'N'){ echo "<a href='https://".$_SERVER["SERVER_NAME"]."/Shibboleth.sso/Logout?return=".$config->settings->idpLogout."' id='logout' title='" . _("logout")."'>"._("logout")."</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
 
                 <span id="setLanguage">
                     <select name="lang" id="lang" class="dropDownLang">

--- a/usage/admin/configuration_sample.ini
+++ b/usage/admin/configuration_sample.ini
@@ -9,7 +9,8 @@ authModule=
 authDatabaseName=
 useOutliers=
 baseURL = ""
-remoteAuthVariableName="HTTP_SERVER_VARS['REMOTE_USER']"
+remoteAuthVariableName="_SERVER['REMOTE_USER']"
+#idpLogout="https://idp.youruniversity/idp/profile/Logout"
 
 
 [database]

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -107,6 +107,8 @@ $coralURL = $util->getCORALURL();
                 </span><br />
 
             <?php if($config->settings->authModule == 'Y'){ echo "<a href='" . $coralURL . "auth/?logout' id='logout'>" . _("logout") . "</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+	     <?php if($config->settings->authModule == 'N'){ echo "<a href='https://".$_SERVER["SERVER_NAME"]."/Shibboleth.sso/Logout?return=".$config->settings->idpLogout."' id='logout' title='" . _("logout")."'>"._("logout")."</a><span id='divider'> | </span><a href='http://docs.coral-erm.org/' id='help' target='_blank'>" . _("Help") . "</a><span id='divider'> | </span>"; } ?>
+
 
                 <span id="setLanguage">
                     <select name="lang" id="lang" class="dropDownLang">


### PR DESCRIPTION
Add back missing Logout buttons when not using Coral Auth module.
Introduce new configuration parameter - idpLogout in configuration_sample.ini of each module to hold Shibboleth IDP Logout URL.
Add htaccess template file by the name of htaccess_sample4shib into the top directory of  each module.

