### PR TITLE
Fix usage module reporting link

### DIFF
--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -196,7 +196,7 @@ $coralURL = $util->getCORALURL();
         </div>
     </a>
 
-    <?php if ($config->settings->reportsModule == "Y") {
+    <?php if ($config->settings->reportingModule == "Y") {
     ?>
     <a href='../reports/' target='_blank'>
         <div class="main-menu-link">


### PR DESCRIPTION
The name reportingModule setting name changed in 2.0 to match the other setting name conventions, but the corresponding menu check did not get updated.  