### PR TITLE
Issue #276: table names needed capitalizing in test_database.sql file.

### DIFF
--- a/tests/_data/test_database.sql
+++ b/tests/_data/test_database.sql
@@ -709,7 +709,7 @@ CREATE TABLE `Document` (
 
 LOCK TABLES `Document` WRITE;
 /*!40000 ALTER TABLE `Document` DISABLE KEYS */;
-INSERT INTO `document` VALUES (1, 'Filler Doc', 1, 1, '2016-10-03', NULL, 'filler_doc.txt', NULL, NULL, '2016-10-03');
+INSERT INTO `Document` VALUES (1, 'Filler Doc', 1, 1, '2016-10-03', NULL, 'filler_doc.txt', NULL, NULL, '2016-10-03');
 /*!40000 ALTER TABLE `Document` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -926,7 +926,7 @@ CREATE TABLE `License` (
 
 LOCK TABLES `License` WRITE;
 /*!40000 ALTER TABLE `License` DISABLE KEYS */;
-INSERT INTO `license` VALUES (1, NULL, 1, 'Filler Doc', NULL, '2016-10-03 22:14:57', '2016-10-03 22:14:57', 1, NULL, 'coral_test', 'coral_test');
+INSERT INTO `License` VALUES (1, NULL, 1, 'Filler Doc', NULL, '2016-10-03 22:14:57', '2016-10-03 22:14:57', 1, NULL, 'coral_test', 'coral_test');
 /*!40000 ALTER TABLE `License` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
This resolves the following issues that I experienced:

> $ mysql < tests/_data/test_database.sql
ERROR 1100 (HY000) at line 712: Table ‘document’ was not locked with LOCK TABLES

> $ mysql < tests/_data/test_database.sql
ERROR 1100 (HY000) at line 929: Table ‘license’ was not locked with LOCK TABLES