### PR TITLE
Delete info.php

### DIFF
--- a/usage/info.php
+++ b/usage/info.php
@@ -1,1 +1,0 @@
-<?php phpinfo(); ?>


### PR DESCRIPTION
We should not be including `phpinfo();` calls in the repository. It will cause unwary users to accidentally expose server configuration information.