### PR TITLE
Utility class and api_client form fixes

### DIFF
--- a/organizations/admin/classes/common/Utility.php
+++ b/organizations/admin/classes/common/Utility.php
@@ -54,7 +54,7 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
+                $pagePath = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\').'/';
 
 		$currentFile = $_SERVER["SCRIPT_NAME"];
 		$parts = Explode('/', $currentFile);

--- a/resources/admin/classes/common/Utility.php
+++ b/resources/admin/classes/common/Utility.php
@@ -54,12 +54,14 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
+		$pagePath = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\').'/';
 
 		$currentFile = $_SERVER["SCRIPT_NAME"];
 		$parts = Explode('/', $currentFile);
 		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
+			if ($parts[$i] != '' && $parts[$i] !='resources'){
+				$pagePath .= $parts[$i] . '/';
+			}
 		}
 
 		return $pagePath;
@@ -79,7 +81,9 @@ class Utility {
 		$currentFile = $_SERVER["PHP_SELF"];
 		$parts = Explode('/', $currentFile);
 		for($i=0; $i<count($parts) - 2; $i++){
-			$pageURL .= $parts[$i] . '/';
+			if ($parts[$i] != 'resources') {
+				$pageURL .= $parts[$i] . '/';
+			}
 		}
 
 		return $pageURL;
@@ -113,7 +117,7 @@ class Utility {
 		if (file_exists($templateFile)){
 
 			$fh = @fopen($templateFile, 'r');
-
+			$defaultMessage = "";
 			while (($buffer = fgets($fh, 4096)) !== false) {
 				$defaultMessage .= $buffer;
 			}

--- a/resources/api_client/index.php
+++ b/resources/api_client/index.php
@@ -10,6 +10,7 @@ $user = $_SERVER['REMOTE_USER'] ? $_SERVER['REMOTE_USER'] : 'API';
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 <link rel="stylesheet" href="pure-min.css">
 </head>
+<body>
 <h1>Simple Resources module API client</h1>
 <h2>Propose a resource</h2>
 <?php
@@ -24,7 +25,7 @@ if (isset($_POST['submitProposeResourceForm'])) {
 		}
     }
     $response = Unirest\Request::post($server . "proposeResource/", $headers, $body);
-    if ($response->body->resourceID) {
+    if (isset($response->body->resourceID)) {
         echo "<p>The resource was correctly submitted (resource " . $response->body->resourceID . ")</p>";
         ?>
         <ul>
@@ -44,7 +45,7 @@ if (isset($_POST['submitProposeResourceForm'])) {
             <li>Format: <?php echo $formatResponse->body; ?></li>
 
             <?php
-            if ($_POST['acquisitionTypeID']) {
+            if (!empty($_POST['acquisitionTypeID'])) {
                 $ATResponse = Unirest\Request::post($server . "getAcquisitionType/" . $_POST['acquisitionTypeID']); ?>
                 <li>Acquisition Type: <?php echo $ATResponse->body; ?></li>
             <?php } ?>
@@ -53,7 +54,7 @@ if (isset($_POST['submitProposeResourceForm'])) {
             <li>Resource Type: <?php echo $RTResponse->body; ?></li>
 
             <?php
-                if ($_POST['administeringSiteID']) {
+                if (isset($_POST['administeringSiteID'])) {
                     echo "<li>Library: ";
                     foreach($_POST['administeringSiteID'] as $as) {
                         $ASResponse = Unirest\Request::post($server . "getAdministeringSite/" . $as);
@@ -242,7 +243,7 @@ function getResourceTypesAsDropdown($server, $headers, $body) {
 function getAcquisitionTypesAsRadio($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getAcquisitionTypes/", $headers, $body);
     foreach ($response->body as $resourceType) {
-        if (strtolower($resourceType->shortName) == "approved" || strtolower($resourceType->shortName) == "need approval") {
+        if (strtolower($resourceType->shortName) == "approved" || strtolower($resourceType->shortName) == "needs approval") {
             echo ' <input type="radio" name="acquisitionTypeID" value="' . $resourceType->acquisitionTypeID . '">' . $resourceType->shortName;
         }
     }
@@ -252,7 +253,7 @@ function getResourceFormatsAsDropdown($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getResourceFormats/", $headers, $body);
     echo '<select name="resourceFormatID">';
     foreach ($response->body as $resourceType) {
-        echo ' <option value="' . $resourceType->resourceFormatID . '">' . $resourceType->shortName . "</option>";
+        echo ' <option value="' . $resourceType->resourceFormatID . '">' . $resourceType->shortName . "</option>\n";
     }
     echo '</select>';
 }
@@ -269,4 +270,5 @@ function getAdministeringSitesAsDropdown($server, $headers, $body) {
 
 
 ?>
+</body>
 </html>

--- a/resources/api_client/index.php
+++ b/resources/api_client/index.php
@@ -13,12 +13,15 @@ $user = $_SERVER['REMOTE_USER'] ? $_SERVER['REMOTE_USER'] : 'API';
 <h1>Simple Resources module API client</h1>
 <h2>Propose a resource</h2>
 <?php
-if ($_POST['submitProposeResourceForm']) {
+$headers = array("Accept" => "application/json");
+$body = array();
+if (isset($_POST['submitProposeResourceForm'])) {
     $fieldNames = array("user", "titleText", "descriptionText", "providerText", "resourceURL", "resourceAltURL", "noteText", "resourceTypeID", "resourceFormatID", "acquisitionTypeID", "administeringSiteID", "homeLocationNote", "licenseRequired", "existingLicense", "publicationYear", "edition", "holdLocation", "patronHold", "CMRanking", "subjectCoverage", "audience", "frequency", "access", "contributingFactors", "ripCode", "fund", "cost");
-    $headers = array("Accept" => "application/json");
-    $body = array();
+
     foreach ($fieldNames as $fieldName) {
-        $body[$fieldName] = $_POST[$fieldName];
+		if (isset($_POST[$fieldName])) {
+			$body[$fieldName] = $_POST[$fieldName];
+		}
     }
     $response = Unirest\Request::post($server . "proposeResource/", $headers, $body);
     if ($response->body->resourceID) {
@@ -83,8 +86,11 @@ if ($_POST['submitProposeResourceForm']) {
         echo "<p>You are not authorized to use this service.</p>";
         echo $response->body;
       }
-      if ($response->code == 500) {
+      elseif ($response->code == 500) {
         echo "<p>This service encountered an error.</p>";
+      }
+      else{
+          echo "<p>This service encountered an unexpected error.</p>\n";
       }
   } else {
 ?>
@@ -131,22 +137,22 @@ if ($_POST['submitProposeResourceForm']) {
 
 <fieldset>
 <legend>Format</legend>
-<?php getResourceFormatsAsDropdown($server); ?>
+<?php getResourceFormatsAsDropdown($server, $headers, $body); ?>
 </fieldset>
 
 <fieldset>
 <legend>Acquisition Type</legend>
-<?php getAcquisitionTypesAsRadio($server); ?>
+<?php getAcquisitionTypesAsRadio($server, $headers, $body); ?>
 </fieldset>
 
 <fieldset>
 <legend>Resource Type</legend>
-<?php getResourceTypesAsDropdown($server); ?>
+<?php getResourceTypesAsDropdown($server, $headers, $body); ?>
 </fieldset>
 
 <fieldset>
 <legend>Library</legend>
-<?php getAdministeringSitesAsDropdown($server); ?>
+<?php getAdministeringSitesAsDropdown($server, $headers, $body); ?>
 </fieldset>
 
 <fieldset>
@@ -224,7 +230,7 @@ if ($_POST['submitProposeResourceForm']) {
 }
 }
 
-function getResourceTypesAsDropdown($server) {
+function getResourceTypesAsDropdown($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getResourceTypes/", $headers, $body);
     echo '<select name="resourceTypeID">';
     foreach ($response->body as $resourceType) {
@@ -233,7 +239,7 @@ function getResourceTypesAsDropdown($server) {
     echo '</select>';
 }
 
-function getAcquisitionTypesAsRadio($server) {
+function getAcquisitionTypesAsRadio($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getAcquisitionTypes/", $headers, $body);
     foreach ($response->body as $resourceType) {
         if (strtolower($resourceType->shortName) == "approved" || strtolower($resourceType->shortName) == "need approval") {
@@ -242,7 +248,7 @@ function getAcquisitionTypesAsRadio($server) {
     }
 }
 
-function getResourceFormatsAsDropdown($server) {
+function getResourceFormatsAsDropdown($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getResourceFormats/", $headers, $body);
     echo '<select name="resourceFormatID">';
     foreach ($response->body as $resourceType) {
@@ -251,7 +257,7 @@ function getResourceFormatsAsDropdown($server) {
     echo '</select>';
 }
 
-function getAdministeringSitesAsDropdown($server) {
+function getAdministeringSitesAsDropdown($server, $headers, $body) {
     $response = Unirest\Request::post($server . "getAdministeringSites/", $headers, $body);
     echo '<select name="administeringSiteID[]" multiple="multiple">';
     foreach ($response->body as $resourceType) {


### PR DESCRIPTION
fixing #223.
This should fix any unexpected slashes in coral paths or urls when calling the getCORALPath or getCORALURL utility functions from the API.  One small addition is a $defaultMessage variable initialization to avoid throwing errors when the template file is opened.

This should also fix some fundamental flaws with the example api_client form.
