### PR TITLE
Issue #306: Check for PHP Notices and Warnings before and after tests.

### DIFF
--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -24,8 +24,16 @@ class Acceptance extends \Codeception\Module {
 		$this->setCookieWithWorkaround("lang", "en_US");
 		$this->setCookieWithWorkaround("CORALLoginID", "coral_test");
 		$this->setCookieWithWorkaround("CORALSessionID", "bNWUrFmjzDtoyxXSyxlwLMROC5W5LwvnAH7sMkRBnBqcyDum1VZCiqRlmngyaRbbYZJl9anncTFQX03PMSSu9jWlN2ZoJ1FiQPJQ");
+
+		$I->dontSee('Notice', 'b');
+		$I->dontSee('Warning', 'b');
 	}
 
+	public function _after(\Codeception\TestInterface $test) {
+		$I = $this->getModule("WebDriver");
+		$I->dontSee('Notice', 'b');
+		$I->dontSee('Warning', 'b');
+	}
 
 	function willAcceptTheNextConfirmBox() {
 		$acceptNextConfirmBox = <<<JS


### PR DESCRIPTION
Addresses #306.

This should be applied in conjunction with #305 because the automated tests are broken until #305 is applied (the `configuration.ini` file path is wrong).

## REVIEW PROCEDURE
Run an automated test with a known PHP Notice or Warning and the test will fail. For example, currently the `LoginCept.php` test will fail with “Notice” printed on the page inside a `<b>` tag.