### PR TITLE
Issue #77: Undefined index: auth/…/Utility.php Line 71

### DIFF
--- a/auth/admin/classes/common/Utility.php
+++ b/auth/admin/classes/common/Utility.php
@@ -68,7 +68,9 @@ class Utility {
 	//returns page URL up to /coral/
 	public function getCORALURL(){
 		$pageURL = 'http';
-		if ($_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
+    if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {
+      $pageURL .= "s";
+    }
 		$pageURL .= "://";
 		if ($_SERVER["SERVER_PORT"] != "80") {
 		  $pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"];


### PR DESCRIPTION
Related to #77.

PHP Notice: Undefined index: HTTPS in ./auth/admin/classes/common/Utility.php on line 71

## To Reproduce
Visit a CORAL instance, like http://coral/auth/, on a non-SSL server.