### PR TITLE
Fix non-ascii apostrophe for translations

### DIFF
--- a/resources/ajax_forms/getImportConfigForm.php
+++ b/resources/ajax_forms/getImportConfigForm.php
@@ -206,7 +206,7 @@
 
 			<fieldset>
 			<legend><?php echo _("Organization Name Mapping");?></legend><div id='resource_organization'>
-			<p><?php echo _("Use these mappings to normalize different variations of an organization’s name to a single value. For example, you could have a publisher with three variations of their name across your import file: PublisherHouse, PublisherH, and PH. You could create a mapping for each one and normalize them all to PublisherHouse, to prevent duplicate organizations from being created. Each column that is added to an Organization set above is checked against the complete list of mappings that you create. ") . "<a id='regexLink' href='https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions' target='_blank'>" . _("PCRE regular expressions") . "</a>" . _(" are supported for these mappings.");?></p>
+			<p><?php echo _("Use these mappings to normalize different variations of an organization's name to a single value. For example, you could have a publisher with three variations of their name across your import file: PublisherHouse, PublisherH, and PH. You could create a mapping for each one and normalize them all to PublisherHouse, to prevent duplicate organizations from being created. Each column that is added to an Organization set above is checked against the complete list of mappings that you create. ") . "<a id='regexLink' href='https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions' target='_blank'>" . _("PCRE regular expressions") . "</a>" . _(" are supported for these mappings.");?></p>
 			<div id='importConfigOrgMapping'>
 				<table id='org_mapping_table' >
 					<tr>


### PR DESCRIPTION
Non-ascii characters in the code strings make gettext unhappy:

```
find . -type f -iname '*.php' -o -iname '*.js' | grep -v "plugins" | xgettext -j -f -
xgettext: Non-ASCII string at ./ajax_forms/getImportConfigForm.php:209
```
I've only found one occurrence of a non-ascii character so far, here's the patch to replace it with its ascii equivalent.

