### PR TITLE
Issue #306: Add a custom action to check for PHP messages.

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -20,7 +20,11 @@ class AcceptanceTester extends \Codeception\Actor
 {
     use _generated\AcceptanceTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+	public function checkForPhpMessages() {
+		$I = $this;
+		$I->cantSee('Fatal error', 'b');
+		$I->cantSee('Warning', 'b');
+		$I->cantSee('Notice', 'b');
+	}
+
 }


### PR DESCRIPTION
Addresses #306. (Replaces PR #307.) 

This should be applied in conjunction with #312 because the automated tests are broken until #312 is applied (the `configuration.ini` file path is wrong).

This PR adds an action that can be included in tests called `checkForPhpMessages()` which ideally should be used after `amOnPage()` and `click()` assertions, like:
```php
$I->amOnPage("/auth/");
$I->checkForPhpMessages();
…
$I->click("#loginbutton");
$I->checkForPhpMessages();
```

## REVIEW PROCEDURE
Add the `$I->checkForPhpMessages();` assertion to an automated test with a known PHP Notice or Warning and the test will fail. For example, currently the `LoginCept.php` test will fail with “Notice” printed on the page inside a `<b>` tag.