### PR TITLE
Issue #318: Modify `configuration` column type of `ImportConfig` table.

### DIFF
--- a/resources/install/protected/2.1.0/001-318.sql
+++ b/resources/install/protected/2.1.0/001-318.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `ImportConfig` MODIFY `configuration` TEXT;


### PR DESCRIPTION
Addresses #318. Merge and release strategy for `*.sql` files still to be worked out (see #302).

## REVIEW PROCEDURE
Run a `mysql` command similar to the following to apply the change.
```
mysql coral_resources < resources/install/protected/2.1.0/001-318.sql 
```
After running, check that the data type for the `configuration` column in the `ImportConfig` table is now `TEXT`.