### PR TITLE
Issue #326: Fix statically called non-static method.

### DIFF
--- a/auth/admin/classes/common/Configuration.php
+++ b/auth/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 

--- a/licensing/admin/classes/common/Configuration.php
+++ b/licensing/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 

--- a/management/admin/classes/common/Configuration.php
+++ b/management/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 

--- a/organizations/admin/classes/common/Configuration.php
+++ b/organizations/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 

--- a/resources/admin/classes/common/Configuration.php
+++ b/resources/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 

--- a/usage/admin/classes/common/Configuration.php
+++ b/usage/admin/classes/common/Configuration.php
@@ -32,7 +32,7 @@ class Configuration extends DynamicObject {
 
 		// Save config array content as Configuration properties
 		foreach ($config as $section => $entries) {
-			$this->$section = Utility::objectFromArray($entries);
+      $this->$section = (new Utility())->objectFromArray($entries);
 		}
 	}
 


### PR DESCRIPTION
Addresses #326.

## Review Procedure
Enable PHP error reporting for E_DEPRECATED and load any CORAL page besides the root index and there will be Deprecated messages. Apply this fix and Deprecated messages for this issue are no longer there.