### PR TITLE
SirsiDynix Issues: Manual Stats Imports failing

### DIFF
--- a/usage/admin/classes/common/Utility.php
+++ b/usage/admin/classes/common/Utility.php
@@ -123,6 +123,9 @@ class Utility {
 			$fc = file_get_contents($fileName);
 		}else{
 			$fc = iconv('windows-1250', 'utf-8', file_get_contents($fileName));
+            if(empty($fc)){
+                $fc = mb_convert_encoding(file_get_contents($fileName),'utf-8');
+            }
 		}
 
     	$handle=fopen("php://memory", "rw");

--- a/usage/uploadComplete.php
+++ b/usage/uploadComplete.php
@@ -16,7 +16,6 @@
 **************************************************************************************************************************
 */
 
-
 ini_set("auto_detect_line_endings", true); //sometimes with macs...
 include_once 'directory.php';
 
@@ -37,27 +36,37 @@ $layoutID = $_POST['layoutID'];
 $importLogID = $_POST['importLogID'];
 $startDate = $_POST['startDate'];
 $numMonths = $_POST['numMonths'];
-$startYearArr = explode("-", $startDate);
-$startYear = $startYearArr[1];
-$startMonthArr = explode("-", $startDate);
-$startMonth = date("n",strtotime($startMonthArr[0]));
-$holdStartMonth = $startMonth;
-$endMonth = date("n",mktime(0,0,0,$startMonth+$numMonths-1));
-if($startMonth <= $endMonth) {
+
+if(empty($startDate)){
+    $startMonth = null;
+    $holdStartMonth = null;
+    $endMonth = null;
+    $startYear = $_POST['checkYear'];
+} else {
+    $startYearArr = explode("-", $startDate);
+    $startYear = $startYearArr[1];
+    $startMonthArr = explode("-", $startDate);
+    $startMonth = date("n",strtotime($startMonthArr[0]));
+    $holdStartMonth = $startMonth;
+    $endMonth = date("n",mktime(0,0,0,$startMonth+$numMonths-1));
+}
+
+if(empty($startMonth) || $startMonth <= $endMonth) {
 	$endYear = $startYear;
 	$multYear = false;//lets us know that we don't need to account for multiple years
-}
-else {
-	$endYear = $startYear + 1;
+} else {
+    $endYear = $startYear + 1;
 	$multYear = true;//lets us know that we need to account for multiple years
 	$holdEndMonth = $endMonth;
 	$endMonth = 12;
 }
 
-if ($_POST['checkYear'] == NULL)
+if ($_POST['checkYear'] == NULL){
 	$year = $startYear;
-else
+} else {
 	$year = $_POST['checkYear'];
+}
+
 $pISSNArray = array();
 $platformArray = array();
 


### PR DESCRIPTION
## Problem
The hidden form at the bottom of [uploadConfirmation.php](https://github.com/coral-erm/coral/blob/development/usage/uploadConfirmation.php#L342) does not contain a `startDate` & `numMonths` value when manually importing stats file. This caused the scripts in [uploadComplete.php](https://github.com/coral-erm/coral/blob/development/usage/uploadComplete.php#L38)(line 38-55) to incorrectly set the `$multYear` var to true.

## Note about solution
To avoid any unnecessary meddling in how uploadConfirmation.php generates its variables, I decided to add additional logic to check for the existence of the `startDate`. As I understand it, there is a feature request to allow manual multi-year imports, at which point the logic for finding the start/end dates of an import file can be added. But this patch works until that development can be completed.

## iconv()
Additionally, it appears that `iconv()` in the [Utility.php](https://github.com/coral-erm/coral/blob/development/usage/admin/classes/common/Utility.php#L125) class has a (known bug)[http://php.net/manual/en/function.iconv.php#108643], which causes it to return `false` if it comes across an invalid character. This was cause the confirmation page to error out and not display any data to check. However, if the problem is not global across coral installs, that suggests the bug might be linked to OS and/or php version. Thus, instead of outright replacing `iconv()`, I've added a check for an empty return, and (if true), it will run the file through `mb_convert_encoding()` instead.

## Review Procedure
Download the following sample files. __File > Download as > Tab-separated values__. Make sure the files have a `.txt` extension

[JR1 R4 example](https://docs.google.com/spreadsheets/d/18uLqxppOpdpIgMm5Xze1OtdJBIGMdfvbyxsjCL_8LQw/edit?usp=sharing)
[BR2 R4 example](https://docs.google.com/spreadsheets/d/1u_jzjPzojJNuxbirkfEXDXxdKISbycT62e82LYi9jBw/edit?usp=sharing)
[BR1 R4 example](https://docs.google.com/spreadsheets/d/1tin4S-TyTaBYPyg4tth2EO4TbCO8ckVV8Dyc-gAwu9I/edit?usp=sharing)
[DB1 R4 example](https://docs.google.com/spreadsheets/d/19Cy2lJV_jSM_uocddzjj4OwCIbNBxKok0TE1XzjREBQ/edit?usp=sharing)

__OR__

Use your own sample reports.

For each test file, in the Usage Module
1. File Import
2. Choose the test file
3. Choose the correct report type
4. Click 'Upload'
5. Confirmation should display correctly
6. Click 'confirm'
7. Stats should import without error
8. Click 'Usage Reports'
9. Select the 'Usage Statistics - Provider Rollup' report and make sure the stats match and/or display without error.

Next, check that the SUSHI functionality didn't break:

1. Click SUSHI
2. Click 'Run Now' from an available publisher (selecting any dates), then 'Submit for Processing'
3. Click 'View to process' in the newly created entry of the Outstanding Import Queue
4. Click 'Confirm'
5. The SUSHI report should be processed and added without any errors.
