### PR TITLE
Fix autoload

### DIFF
--- a/auth/directory.php
+++ b/auth/directory.php
@@ -24,7 +24,7 @@ define('BASE_DIR', dirname(__FILE__) . '/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -43,7 +43,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {

--- a/licensing/directory.php
+++ b/licensing/directory.php
@@ -22,7 +22,7 @@ define('BASE_DIR', dirname(__FILE__) . '/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -41,7 +41,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {

--- a/management/directory.php
+++ b/management/directory.php
@@ -22,7 +22,7 @@ define('BASE_DIR', dirname(__FILE__) . '/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -41,7 +41,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {

--- a/organizations/directory.php
+++ b/organizations/directory.php
@@ -24,7 +24,7 @@ define('BASE_DIR', dirname(__FILE__) . '/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -43,7 +43,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -2,30 +2,6 @@
 require 'Flight/flight/Flight.php';
 
 include_once '../directory.php';
-include_once '../admin/classes/common/NamedArguments.php';
-include_once '../admin/classes/common/Object.php';
-include_once '../admin/classes/common/DynamicObject.php';
-include_once '../admin/classes/common/Utility.php';
-include_once '../admin/classes/common/Configuration.php';
-include_once '../admin/classes/common/DBService.php';
-include_once '../admin/classes/common/DatabaseObject.php';
-include_once '../admin/classes/common/Email.php';
-include_once '../admin/classes/domain/Resource.php';
-include_once '../admin/classes/domain/ResourceType.php';
-include_once '../admin/classes/domain/AcquisitionType.php';
-include_once '../admin/classes/domain/ResourceFormat.php';
-include_once '../admin/classes/domain/NoteType.php';
-include_once '../admin/classes/domain/ResourceNote.php';
-include_once '../admin/classes/domain/ResourcePayment.php';
-include_once '../admin/classes/domain/AdministeringSite.php';
-include_once '../admin/classes/domain/ResourceAdministeringSiteLink.php';
-include_once '../admin/classes/domain/Status.php';
-include_once '../admin/classes/domain/User.php';
-include_once '../admin/classes/domain/Workflow.php';
-include_once '../admin/classes/domain/Step.php';
-include_once '../admin/classes/domain/ResourceStep.php';
-include_once '../admin/classes/domain/UserGroup.php';
-include_once '../admin/classes/domain/Fund.php';
 
 if (!isAllowed()) {
     header('HTTP/1.0 403 Forbidden');

--- a/resources/directory.php
+++ b/resources/directory.php
@@ -24,7 +24,7 @@ define('BASE_DIR', dirname(__FILE__) . '/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -43,7 +43,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {

--- a/usage/directory.php
+++ b/usage/directory.php
@@ -28,7 +28,7 @@ define('ADMIN_DIR', BASE_DIR . 'admin/');
 define('CLASSES_DIR', ADMIN_DIR . 'classes/');
 
 // Automatically load undefined classes from subdirectories of |CLASSES_DIR|.
-function __autoload( $className ) {
+spl_autoload_register(function ( $className ) {
 	if (file_exists(CLASSES_DIR) && is_readable(CLASSES_DIR) && is_dir(CLASSES_DIR)) {
 		$directory = dir(CLASSES_DIR);
 
@@ -47,7 +47,7 @@ function __autoload( $className ) {
 		}
 		$directory->close();
 	}
-}
+});
 
 // Add lcfirst() for PHP < 5.3.0
 if (false === function_exists('lcfirst')) {


### PR DESCRIPTION
The use of php's __autoload was not recommended in the past, and it is now deprecated.

cf: http://php.net/manual/en/language.oop5.autoload.php
> Although the __autoload() function can also be used for autoloading classes and interfaces, it's preferred to use the spl_autoload_register() function. This is because it is a more flexible alternative (enabling for any number of autoloaders to be specified in the application, such as in third party libraries). For this reason, using __autoload() is discouraged and it may be deprecated in the future.

By experience, I've also seen that __autoload sometimes behave strangely.

This PR replaces all calls to __autoload with spl_autoload_register.

Moreover, it allows to remove all unnecessary explicit inclusions in the API.
