### PR TITLE
Fix API for multiple orders on resource creation

### DIFF
--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -46,7 +46,7 @@ Flight::route('/proposeResource/', function(){
     $resource->mandatoryResource            = '';
     $resource->resourceID                   = null;
 
-    $fieldNames = array("titleText", "descriptionText", "providerText", "resourceURL", "resourceAltURL", "noteText", "resourceTypeID", "resourceFormatID", "acquisitionTypeID");
+    $fieldNames = array("titleText", "descriptionText", "providerText", "resourceURL", "resourceAltURL", "noteText", "resourceTypeID", "resourceFormatID");
     foreach ($fieldNames as $fieldName) {
         $resource->$fieldName = Flight::request()->data->$fieldName;
     }
@@ -54,6 +54,14 @@ Flight::route('/proposeResource/', function(){
         $resource->save();
         $resourceID = $resource->primaryKey;
         $resource = new Resource(new NamedArguments(array('primaryKey' => $resourceID)));
+
+		// Create the default order
+		$resourceAcquisition = new ResourceAcquisition();
+		$resourceAcquisition->resourceID = $resourceID;
+		$resourceAcquisition->subscriptionStartDate = date("Y-m-d");
+		$resourceAcquisition->subscriptionEndDate = date("Y-m-d");
+		$resourceAcquisition->acquisitionTypeID = Flight::request()->data->acquisitionTypeID;
+		$resourceAcquisition->save();
 
         //add administering site
         if (Flight::request()->data['administeringSiteID']) {

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -68,7 +68,7 @@ Flight::route('/proposeResource/', function(){
             foreach (Flight::request()->data['administeringSiteID'] as $administeringSiteID) {
                 $resourceAdministeringSiteLink = new ResourceAdministeringSiteLink();
                 $resourceAdministeringSiteLink->resourceAdministeringSiteLinkID = '';
-                $resourceAdministeringSiteLink->resourceID = $resourceID;
+                $resourceAdministeringSiteLink->resourceAcquisitionID = $resourceAcquisition->resourceAcquisitionID;
                 $resourceAdministeringSiteLink->administeringSiteID = $administeringSiteID;
                 try {
                     $resourceAdministeringSiteLink->save();
@@ -89,7 +89,7 @@ Flight::route('/proposeResource/', function(){
                 $resourceNote->updateDate       = date( 'Y-m-d' );
                 $resourceNote->noteTypeID       = $noteTypeID;
                 $resourceNote->tabName          = 'Product';
-                $resourceNote->resourceID       = $resourceID;
+                $resourceNote->entityID         = $resourceID;
                 $resourceNote->noteText         = Flight::request()->data[$key];
                 $resourceNote->save();
             }
@@ -112,7 +112,7 @@ Flight::route('/proposeResource/', function(){
             $resourceNote->updateDate       = date( 'Y-m-d' );
             $resourceNote->noteTypeID       = $noteTypeID;
             $resourceNote->tabName          = 'Product';
-            $resourceNote->resourceID       = $resourceID;
+            $resourceNote->entityID         = $resourceID;
             $resourceNote->noteText         = $noteText;
             $resourceNote->save();
         }
@@ -130,7 +130,7 @@ Flight::route('/proposeResource/', function(){
             $resourceNote->updateDate       = date( 'Y-m-d' );
             $resourceNote->noteTypeID       = $noteTypeID;
             $resourceNote->tabName          = 'Acquisitions';
-            $resourceNote->resourceID       = $resourceID;
+            $resourceNote->entityID         = $resourceAcquisition->resourceAcquisitionID;
             $resourceNote->noteText         = $noteText;
             $resourceNote->save();
         }
@@ -145,7 +145,7 @@ Flight::route('/proposeResource/', function(){
                 $resourceNote->updateDate       = date( 'Y-m-d' );
                 $resourceNote->noteTypeID       = $noteTypeID;
                 $resourceNote->tabName          = 'Product';
-                $resourceNote->resourceID       = $resourceID;
+                $resourceNote->entityID         = $resourceID;
                 $resourceNote->noteText         = $value . ": " . Flight::request()->data[$key];
                 $resourceNote->save();
             }
@@ -166,7 +166,7 @@ Flight::route('/proposeResource/', function(){
             $resourceNote->updateDate       = date( 'Y-m-d' );
             $resourceNote->noteTypeID       = $noteTypeID;
             $resourceNote->tabName          = 'Product';
-            $resourceNote->resourceID       = $resourceID;
+            $resourceNote->entityID         = $resourceID;
             $resourceNote->noteText         = $noteText;
             $resourceNote->save();
         }
@@ -182,7 +182,7 @@ Flight::route('/proposeResource/', function(){
             $rp->costDetailsID = '';
             $rp->costNote = '';
             $rp->invoiceNum = '';
-            $rp->resourceID = $resourceID;
+            $rp->resourceAcquisitionID = $resourceAcquisition->resourceAcquisitionID;
             $rp->paymentAmount = cost_to_integer(Flight::request()->data['cost']);
             $rp->currencyCode = 'USD';
             $rp->orderTypeID = 2;


### PR DESCRIPTION
This PR allows #344 to work with #244 .
More specifically, a default order needs to be created when submitting a resource through the API, in order to be able to attach the acquisition type to it.