### PR TITLE
Fix Remove resource

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -428,7 +428,7 @@ class Resource extends DatabaseObject {
 	public function getContacts() {
 
 		$query = "SELECT * FROM Contact
-					WHERE resourceID = '" . $this->resourceID . "'";
+					WHERE resourceAcquisitionID = '" . $this->resourceID . "'";
 
 		$result = $this->db->processQuery($query, 'assoc');
 


### PR DESCRIPTION
This is a fix for #244 to allow resource removal.  Currently on development if you try to remove a resource, you will get an error that there is no resourceID in the where clause.  This is triggered because a foreign key was updated in the big sql update, but not in the resource class for the function getContacts().

test plan:
1. from the resource module, click in to a resource
2. click the X to remove resource.