### PR TITLE
Remove orders on resource deletion

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1448,7 +1448,7 @@ class Resource extends DatabaseObject {
 
 		$query = "DELETE
 			FROM ResourceNote
-			WHERE resourceID = '" . $this->resourceID . "'";
+			WHERE entityID = '" . $this->resourceID . "'";
 
 		$result = $this->db->processQuery($query);
 	}

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -424,28 +424,6 @@ class Resource extends DatabaseObject {
 	}
 
 
-	//returns array of contact objects
-	public function getContacts() {
-
-		$query = "SELECT * FROM Contact
-					WHERE resourceID = '" . $this->resourceID . "'";
-
-		$result = $this->db->processQuery($query, 'assoc');
-
-		$objects = array();
-
-		//need to do this since it could be that there's only one request and this is how the dbservice returns result
-		if (isset($result['contactID'])) { $result = [$result]; }
-		foreach ($result as $row) {
-			$object = new Contact(new NamedArguments(array('primaryKey' => $row['contactID'])));
-			array_push($objects, $object);
-		}
-
-		return $objects;
-	}
-
-
-
 	//returns array of externalLogin objects
 	public function getExternalLogins() {
 
@@ -1411,12 +1389,10 @@ class Resource extends DatabaseObject {
 		$this->removeAllSubjects();
 		$this->removeAllIsbnOrIssn();
 
-
-		$instance = new Contact();
-		foreach ($this->getContacts() as $instance) {
-			$instance->removeContactRoles();
-			$instance->delete();
-		}
+        $instance = new ResourceAcquisition();
+        foreach($this->getResourceAcquisitions() as $instance) {
+            $instance->removeResourceAcquisition();
+        }
 
 		$instance = new ExternalLogin();
 		foreach ($this->getExternalLogins() as $instance) {

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1454,19 +1454,6 @@ class Resource extends DatabaseObject {
 	}
 
 
-
-	//removes resource steps
-	public function removeResourceSteps() {
-
-		$query = "DELETE
-			FROM ResourceStep
-			WHERE resourceID = '" . $this->resourceID . "' AND archivingDate IS NOT NULL";
-
-		$result = $this->db->processQuery($query);
-	}
-
-
-
 	//search used for the resource autocomplete
 	public function resourceAutocomplete($q) {
 		$resourceArray = array();

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1404,11 +1404,6 @@ class Resource extends DatabaseObject {
 			$instance->delete();
 		}
 
-		$instance = new Attachment();
-		foreach ($this->getAttachments() as $instance) {
-			$instance->delete();
-		}
-
 		$instance = new Alias();
 		foreach ($this->getAliases() as $instance) {
 			$instance->delete();

--- a/resources/admin/classes/domain/ResourceAcquisition.php
+++ b/resources/admin/classes/domain/ResourceAcquisition.php
@@ -469,8 +469,10 @@ class ResourceAcquisition extends DatabaseObject {
         $this->deleteAccess();
         $this->deleteContacts();
         $this->deleteAttachments();
+        $this->deleteNotes();
         $this->delete();
     }
+
 
 	//removes resource licenses
 	public function removeResourceLicenses() {
@@ -623,6 +625,14 @@ class ResourceAcquisition extends DatabaseObject {
     public function deleteAttachments() {
         foreach ($this->getAttachments() as $s) {
             $s->delete();
+        }
+    }
+
+    public function deleteNotes() {
+        foreach (array("Acquisitions", "Access", "Cataloging") as $tabName) {
+            foreach ($this->getNotes($tabName) as $s) {
+                $s->delete();
+            }
         }
     }
 

--- a/resources/admin/classes/domain/ResourceAcquisition.php
+++ b/resources/admin/classes/domain/ResourceAcquisition.php
@@ -616,8 +616,8 @@ class ResourceAcquisition extends DatabaseObject {
     }
 
     public function deleteContacts() {
-        foreach ($this->getUnarchivedContacts() as $s) {
-            $c = new Contact(new NamedArguments(array('primaryKey' => $s['contactID'])));
+        foreach ($this->getContacts() as $c) {
+            $c->removeContactRoles();
             $c->delete();
         }
     }
@@ -748,6 +748,25 @@ class ResourceAcquisition extends DatabaseObject {
 		return $contactsArray;
 	}
 
+	//returns array of contact objects
+	public function getContacts() {
+
+		$query = "SELECT * FROM Contact
+					WHERE resourceAcquisitionID = '" . $this->resourceAcquisitionID . "'";
+
+		$result = $this->db->processQuery($query, 'assoc');
+
+		$objects = array();
+
+		//need to do this since it could be that there's only one request and this is how the dbservice returns result
+		if (isset($result['contactID'])) { $result = [$result]; }
+		foreach ($result as $row) {
+			$object = new Contact(new NamedArguments(array('primaryKey' => $row['contactID'])));
+			array_push($objects, $object);
+		}
+
+		return $objects;
+	}
 
 
 	//removes payment records

--- a/resources/ajax_htmldata/getAcquisitionsDetails.php
+++ b/resources/ajax_htmldata/getAcquisitionsDetails.php
@@ -312,7 +312,7 @@
 		}else{
 			if ($user->canEdit()){
 			?>
-				<a href='ajax_forms.php?action=getNoteForm&height=233&width=410&tab=Acquisitions&entityID=<?php echo $resourceID; ?>&resourceNoteID=&modal=true' class='thickbox'><?php echo _("add new note");?></a>
+				<a href='ajax_forms.php?action=getNoteForm&height=233&width=410&tab=Acquisitions&entityID=<?php echo $resourceAcquisitionID; ?>&resourceNoteID=&modal=true' class='thickbox'><?php echo _("add new note");?></a>
 			<?php
 			}
 		}

--- a/resources/ajax_htmldata/getContactDetails.php
+++ b/resources/ajax_htmldata/getContactDetails.php
@@ -21,7 +21,7 @@
 		if ((isset($archiveInd)) && ($archiveInd == "1")){
 			//if we want archives to be displayed
 			if ($showArchivesInd == "1"){
-				if (count($resource->getArchivedContacts()) > 0){
+				if (count($resourceAcquisition->getArchivedContacts()) > 0){
 					echo "<i><b>"._("The following are archived contacts:")."</b></i>";
 				}
 				$contactArray = $resourceAcquisition->getArchivedContacts();
@@ -186,7 +186,7 @@
 
 
 			if ($user->canEdit() && ($orgContactFlag == 0) && ($showArchivesInd != 1)){ ?>
-				<a href='ajax_forms.php?action=getContactForm&height=389&width=620&modal=true&type=named&resourceID=<?php echo $resourceID; ?>' class='thickbox' id='newNamedContact'><?php echo _("add contact");?></a>
+				<a href='ajax_forms.php?action=getContactForm&height=389&width=620&modal=true&type=named&resourceAcquisitionID=<?php echo $resourceAcquisitionID; ?>' class='thickbox' id='newNamedContact'><?php echo _("add contact");?></a>
 				<br /><br /><br />
 			<?php
 			}
@@ -196,18 +196,18 @@
 			if (($archiveInd != 1) && ($showArchivesInd != 1)){
 				echo "<i>"._("No contacts available")."</i><br /><br />";
 				if (($user->canEdit())){ ?>
-					<a href='ajax_forms.php?action=getContactForm&height=389&width=620&modal=true&type=named&resourceID=<?php echo $resourceID; ?>' class='thickbox' id='newNamedContact'><?php echo _("add contact");?></a>
+					<a href='ajax_forms.php?action=getContactForm&height=389&width=620&modal=true&type=named&resourceAcquisitionID=<?php echo $resourceAcquisitionID; ?>' class='thickbox' id='newNamedContact'><?php echo _("add contact");?></a>
 					<br /><br /><br />
 				<?php
 				}
 			}
 		}
 
-		if (($showArchivesInd == "0") && ($archiveInd == "1") && (count($resource->getArchivedContacts()) > 0)){
-			echo "<i>" . count($resource->getArchivedContacts()) . _(" archived contact(s) available.")."  <a href='javascript:updateArchivedContacts(1);'>"._("show archived contacts")."</a></i><br />";
+		if (($showArchivesInd == "0") && ($archiveInd == "1") && (count($resourceAcquisition->getArchivedContacts()) > 0)){
+			echo "<i>" . count($resourceAcquisition->getArchivedContacts()) . _(" archived contact(s) available.")."  <a href='javascript:updateArchivedContacts(1);'>"._("show archived contacts")."</a></i><br />";
 		}
 
-		if (($showArchivesInd == "1") && ($archiveInd == "1") && (count($resource->getArchivedContacts()) > 0)){
+		if (($showArchivesInd == "1") && ($archiveInd == "1") && (count($resourceAcquisition->getArchivedContacts()) > 0)){
 			echo "<i><a href='javascript:updateArchivedContacts(0);'>"._("hide archived contacts")."</a></i><br />";
 		}
 

--- a/resources/ajax_processing/submitNewResource.php
+++ b/resources/ajax_processing/submitNewResource.php
@@ -82,7 +82,7 @@
 				$resourceNote->updateDate		= date( 'Y-m-d' );
 				$resourceNote->noteTypeID 		= $noteType->getInitialNoteTypeID();
 				$resourceNote->tabName 			= 'Product';
-				$resourceNote->resourceID 		= $resourceID;
+				$resourceNote->entityID 		= $resourceID;
 
 				//only insert provider as note if it's been submitted
 				if (($_POST['providerText']) && (!$_POST['organizationID']) && ($_POST['resourceStatus'] == 'progress')){

--- a/resources/js/resource.js
+++ b/resources/js/resource.js
@@ -432,7 +432,7 @@ function updateArchivedContacts(showArchivedPassed){
 	 type:       "GET",
 	 url:        "ajax_htmldata.php",
 	 cache:      false,
-	 data:       "action=getContactDetails&resourceID=" + $("#resourceID").val() + "&archiveInd=1&showArchivesInd=" + showArchivedContacts,
+	 data:       "action=getContactDetails&resourceID=" + $("#resourceID").val() + "&resourceAcquisitionID=" + $("#resourceAcquisitionSelect").val() + "&archiveInd=1&showArchivesInd=" + showArchivedContacts,
 	 success:    function(html) {
 		$("#div_archivedContactDetails").html(html);
 		bind_removes();

--- a/resources/resources/cataloging.php
+++ b/resources/resources/cataloging.php
@@ -228,7 +228,7 @@ if (count($noteArray) > 0){
 }else{
 if ($user->canEdit()){
 ?>
-	<a href='ajax_forms.php?action=getNoteForm&height=233&width=410&tab=Cataloging&resourceID=<?php echo $resourceID; ?>&resourceNoteID=&modal=true' class='thickbox'><?php echo _("add new note");?></a>
+	<a href='ajax_forms.php?action=getNoteForm&height=233&width=410&tab=Cataloging&entityID=<?php echo $resourceAcquisitionID; ?>&resourceNoteID=&modal=true' class='thickbox'><?php echo _("add new note");?></a>
 <?php
 }
 }


### PR DESCRIPTION
Since contacts are now linked to orders, orders are to be deleted when a resource is deleted (note: I have the feeling that this was already done before, but it may have been lost in a merge / rebase).

Also fixes #348 