### PR TITLE
fixes #361

### DIFF
--- a/resources/api_client/index.php
+++ b/resources/api_client/index.php
@@ -50,9 +50,11 @@ if (isset($_POST['submitProposeResourceForm'])) {
 //        addToDescriptionText($body,$descField);
 //    }
 
-    if(isset($body['neededByDate'])){
-        $body['neededByDate'] = 'Needed by '.date("m/d/Y", strtotime($body['neededByDate']));
-    }
+	if(!empty($body['neededByDate'])){
+		$body['neededByDate'] = 'Needed by '.date("m/d/Y", strtotime($body['neededByDate']));
+	} else if(isset($body['neededByDate'])){
+		unset($body['neededByDate']);
+	}
 
     $response = Unirest\Request::post($server . "proposeResource/", $headers, $body);
     if (isset($response->body->resourceID)) {


### PR DESCRIPTION
probably not needed, but here's a testplan.
without this PR:
1. submit a new resource with the api_form, but don't fill in the neededBy date input. (it should be hidden unless you check the 'urgent' checkbox.)
2. look at the new resource record and you'll see an initial note with a neededBy date of 12/31/1969 or 01/01/1970.

with this PR:
2. you should not see a neededBy date at all in the initial note section.