### PR TITLE
API: Fix licenses route

### DIFF
--- a/licensing/admin/classes/domain/License.php
+++ b/licensing/admin/classes/domain/License.php
@@ -38,6 +38,10 @@ class License extends DatabaseObject {
                 $expressionType = new ExpressionType(new NamedArguments(array('primaryKey' => $expression->expressionTypeID)));
                 if ($expressionType->noteType == "Display") {
                     $larray['documents'][$doccount]['expressions'][$exprcount]['content'] = $expression->asArray();
+                    foreach ($expression->getQualifiers() as $qualifier) {
+                        $larray['documents'][$doccount]['expressions'][$exprcount]['qualifiers'][] = $qualifier->shortName;
+                    }
+
                     $notescount = 0;
                     foreach ($expression->getExpressionNotes() as $expressionNote) {
                         $larray['documents'][$doccount]['expressions'][$exprcount]['notes'][$notescount] = $expressionNote->asArray();;

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -56,6 +56,13 @@ class Resource extends DatabaseObject {
 		foreach ($identifiers as $identifier) {
 				array_push($rarray['isbnOrIssn'], $identifier->isbnOrIssn);
 		}
+
+        $aliases = $this->getAliases();
+        $rarray['aliases'] = array();
+		foreach ($aliases as $alias) {
+				array_push($rarray['aliases'], $alias->shortName);
+		}
+
 		return $rarray;
 		
   
@@ -196,7 +203,6 @@ class Resource extends DatabaseObject {
 
     // return array of related resource objects
     private function getRelatedResources($key) {
-
         $query = "SELECT rr.resourceRelationshipID
 			FROM ResourceRelationship rr
             JOIN Resource r on rr.resourceID = r.resourceID

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -349,8 +349,8 @@ Flight::route('GET /resources/@id/licenses', function($id) {
     $db = DBService::getInstance();
     $r = new Resource(new NamedArguments(array('primaryKey' => $id)));
     $ras = $r->getResourceAcquisitions();
+    $licensesArray = array();
     foreach ($ras as $ra) {
-        $licensesArray = array();
         $rla = $ra->getLicenseArray();
         $db->changeDb('licensingDatabaseName');
         foreach($rla as $license) {

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -3,6 +3,14 @@ require 'vendor/autoload.php';
 
 include_once '../directory.php';
 
+# We still need to manually include classes from other modules
+include_once '../../licensing/admin/classes/domain/License.php';
+include_once '../../licensing/admin/classes/domain/Document.php';
+include_once '../../licensing/admin/classes/domain/DocumentType.php';
+include_once '../../licensing/admin/classes/domain/Expression.php';
+include_once '../../licensing/admin/classes/domain/ExpressionNote.php';
+include_once '../../licensing/admin/classes/domain/ExpressionType.php';
+
 if (!isAllowed()) {
     header('HTTP/1.0 403 Forbidden');
     echo "Unauthorized IP: " . $_SERVER['REMOTE_ADDR'];
@@ -321,14 +329,17 @@ Flight::route('GET /resources/@id/titles', function($id) {
 Flight::route('GET /resources/@id/licenses', function($id) {
     $db = DBService::getInstance();
     $r = new Resource(new NamedArguments(array('primaryKey' => $id)));
-	$licensesArray = array();
-    $rla = $r->getLicenseArray();
-    $db->changeDb('licensingDatabaseName');
-	foreach($rla as $license) {
-		$l = new License(new NamedArguments(array('primaryKey' => $license['licenseID'])));
-		array_push($licensesArray, $l->asArray());
-	}
-    $db->changeDb();
+    $ras = $r->getResourceAcquisitions();
+    foreach ($ras as $ra) {
+        $licensesArray = array();
+        $rla = $ra->getLicenseArray();
+        $db->changeDb('licensingDatabaseName');
+        foreach($rla as $license) {
+            $l = new License(new NamedArguments(array('primaryKey' => $license['licenseID'])));
+            array_push($licensesArray, $l->asArray());
+        }
+        $db->changeDb();
+    }
 	Flight::json($licensesArray);
 });
 

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -307,6 +307,25 @@ Flight::route('GET /resources/', function() {
     }
 });
 
+Flight::route('GET /resources/@id/packages', function($id) {
+    $r = new Resource(new NamedArguments(array('primaryKey' => $id)));
+	$parentResourceArray = array();
+	$parentResourceIDArray = array();
+	foreach ($r->getParentResources() as $instance) {
+	   foreach (array_keys($instance->attributeNames) as $attributeName) {
+			$sanitizedInstance[$attributeName] = $instance->$attributeName;
+		}
+		$sanitizedInstance[$instance->primaryKeyName] = $instance->primaryKey;
+		array_push($parentResourceIDArray, $sanitizedInstance);
+	}
+
+	foreach ($parentResourceIDArray as $parentResource){
+		$parentResourceObj = new Resource(new NamedArguments(array('primaryKey' => $parentResource['relatedResourceID'])));
+		array_push($parentResourceArray, $parentResourceObj->asArray());
+	}
+    Flight::json($parentResourceArray);
+});
+
 Flight::route('GET /resources/@id/titles', function($id) {
     $r = new Resource(new NamedArguments(array('primaryKey' => $id)));
 	$childResourceArray = array();

--- a/resources/api/index.php
+++ b/resources/api/index.php
@@ -10,6 +10,7 @@ include_once '../../licensing/admin/classes/domain/DocumentType.php';
 include_once '../../licensing/admin/classes/domain/Expression.php';
 include_once '../../licensing/admin/classes/domain/ExpressionNote.php';
 include_once '../../licensing/admin/classes/domain/ExpressionType.php';
+include_once '../../licensing/admin/classes/domain/Qualifier.php';
 
 if (!isAllowed()) {
     header('HTTP/1.0 403 Forbidden');


### PR DESCRIPTION
The following route is currently broken on devel:
`resources/api/resources/@id/licenses`

> 500 Internal Server Error
> Invalid argument supplied for foreach() (2)
> #0 /home/coral/www/resources/api/index.php(327): flight\Engine->handleError(2, 'Invalid argumen...', '/home/coral/www...', 327, Array)

This PR fixes it.

It also enhance some existing routes:
 - Aliases are now embedded in `resources/api/resources/@id/` response.
 - Qualifiers are now embedded in `resources/api/resources/@id/licenses` response.

It also introduce a new route:
`resources/api/resources/@id/packages` to get the parent resources of a given resource.