### PR TITLE
Make Ebsco KB integration translatable

### DIFF
--- a/resources/ajax_htmldata/getEbscoKbTitleDetails.php
+++ b/resources/ajax_htmldata/getEbscoKbTitleDetails.php
@@ -31,24 +31,24 @@ $title = $ebscoKb->getTitle($titleId);
                 <div class="row">
                     <div class="col-6">
                         <dl>
-                            <dt>Publication Type</dt>
+                            <dt><?php echo _("Publication Type"); ?></dt>
                             <dd><?php echo $title->pubType; ?></dd>
 
                             <?php if(!empty($title->edition)): ?>
-                                <dt>Edition</dt>
+                                <dt><?php echo _("Edition"); ?></dt>
                                 <dd><?php echo $title->edition; ?></dd>
                             <?php endif; ?>
 
-                            <dt>Peer Reviewed</dt>
+                            <dt><?php echo _("Peer Reviewed"); ?></dt>
                             <dd><?php echo $title->isPeerReviewed; ?></dd>
 
-                            <dt>Publisher</dt>
+                            <dt><?php echo _("Publisher"); ?></dt>
                             <dd><?php echo $title->publisherName; ?></dd>
                         </dl>
                     </div>
                     <div class="col-6">
                         <dl>
-                            <dt>Subjects</dt>
+                            <dt><?php echo _("Subjects"); ?></dt>
                             <dd>
                                 <ul>
                                     <?php foreach($title->subjects as $subject): ?>
@@ -57,7 +57,7 @@ $title = $ebscoKb->getTitle($titleId);
                                 </ul>
                             </dd>
 
-                            <dt>ISXNs</dt>
+                            <dt><?php echo _("ISXNs"); ?></dt>
                             <dd>
                                 <ul style="list-style: none; ">
                                     <?php
@@ -65,10 +65,10 @@ $title = $ebscoKb->getTitle($titleId);
                                         if(in_array($identifier['type'], [0,1])) {
                                             switch($identifier['subtype']){
                                                 case 1:
-                                                    $subtype = ' (Print)';
+                                                    $subtype = _(' (Print)');
                                                     break;
                                                 case 2:
-                                                    $subtype = ' (Electronic)';
+                                                    $subtype = _(' (Electronic)');
                                                     break;
                                                 default:
                                                     $subtype = '';
@@ -81,7 +81,7 @@ $title = $ebscoKb->getTitle($titleId);
                             </dd>
 
                             <?php if(!empty($title->contributorList)): ?>
-                                <dt>Contributors</dt>
+                                <dt><?php echo _("Contributors"); ?></dt>
                                 <dd><?php echo implode(', ', $title->contributorList); ?></dd>
                             <?php endif; ?>
                         </dl>
@@ -93,7 +93,7 @@ $title = $ebscoKb->getTitle($titleId);
                 <div class="row">
                     <div class="col-4">
                         <label for="showAllPackages">
-                            <input type="checkbox" id="showAllPackages"> Show all packages
+                            <input type="checkbox" id="showAllPackages"> <?php echo_("Show all packages"); ?>
                         </label>
                     </div>
                 </div>
@@ -106,9 +106,9 @@ $title = $ebscoKb->getTitle($titleId);
                                     <div class="col-8">
                                         <h3 style="padding-left: 5px;">
                                             <?php if($resource->isSelected): ?>
-                                                <i class="fa fa-check-square-o fa-lg text-success" title="Selected in EBSCO Kb" style="margin-left: -15px;"></i>
+                                                <i class="fa fa-check-square-o fa-lg text-success" title="<?php echo _("Selected in EBSCO Kb"); ?>" style="margin-left: -15px;"></i>
                                             <?php else: ?>
-                                                <i class="fa fa-ban fa-lg text-danger" title="Not selected in EBSCO Kb" style="margin-left: -15px;"></i>
+                                                <i class="fa fa-ban fa-lg text-danger" title="<?php echo _("Not selected in EBSCO Kb"); ?>" style="margin-left: -15px;"></i>
                                             <?php endif; ?>
                                             <?php echo $resource->packageName; ?>
                                         </h3>
@@ -131,13 +131,13 @@ $title = $ebscoKb->getTitle($titleId);
                                 </div>
                             </div>
                             <div class="card-body">
-                                <p>Vendor: <?php echo $resource->vendorName; ?></p>
+                                <p><?php echo _("Vendor"); ?>: <?php echo $resource->vendorName; ?></p>
                                 <dl>
-                                    <dt>Coverage Statement</dt>
+                                    <dt><?php echo _("Coverage Statement"); ?></dt>
                                     <dd><?php echo $resource->coverageStatement; ?></dd>
-                                    <dt>Embargo</dt>
+                                    <dt><?php echo _("Embargo"); ?></dt>
                                     <dd><?php echo $resource->embargoStatement; ?></dd>
-                                    <dt>Resource Url</dt>
+                                    <dt><?php echo _("Resource Url"); ?></dt>
                                     <dd><a href="<?php echo $resource->url; ?>"><?php echo $resource->url; ?></a></dd>
                                 </dl>
                             </div>

--- a/resources/ajax_htmldata/getSearchEbscoKb.php
+++ b/resources/ajax_htmldata/getSearchEbscoKb.php
@@ -5,7 +5,7 @@ $params = EbscoKbService::getSearch();
 
 // Don't run a empty title query if no package limit is set
 if(empty($params['search']) && $params['type'] == 'titles' && empty($params['packageId'])){
-    echo '<div style="margin: 2em;"><i>Please enter a search term.</i></div>';
+    echo '<div style="margin: 2em;"><i>' . _('Please enter a search term.') . '</i></div>';
     exit;
 } else {
     $ebscoKb = EbscoKbService::getInstance();
@@ -21,7 +21,7 @@ if(empty($params['search']) && $params['type'] == 'titles' && empty($params['pac
 $totalRecords = $ebscoKb->numResults();
 $items = $ebscoKb->results();
 if(empty($totalRecords) || empty($items)){
-    echo '<div style="margin-bottom: 2em;"><i>No results found.</i></div>';
+    echo '<div style="margin-bottom: 2em;"><i>' . _('No results found.') . '</i></div>';
     exit;
 }
 
@@ -63,8 +63,8 @@ if(!empty($params['vendorId'])){
 <?php if(!empty($vendor) && empty($package)): ?>
     <div>
         <h2>
-            Packages from <?php echo $vendor->vendorName; ?>
-            <small style="padding-left: 1px">(<?php echo $vendor->packagesSelected; ?> of <?php echo $vendor->packagesTotal; ?> selected)</small>
+            <?php echo _('Packages from'); ?> <?php echo $vendor->vendorName; ?>
+            <small style="padding-left: 1px">(<?php echo $vendor->packagesSelected . ' ' .  _('of') . ' ' . $vendor->packagesTotal . ' ' . _('selected)'); ?></small>
         </h2>
     </div>
 <?php endif; ?>
@@ -72,14 +72,14 @@ if(!empty($params['vendorId'])){
 <?php if(!empty($vendor) && !empty($package)): ?>
     <div>
         <h2>
-            Title list from <?php echo $package->packageName; ?><br />
+            <?php echo _('Title list from') . ' ' .  $package->packageName; ?><br />
             <small style="padding-left: 5px;">Vendor: <?php echo $vendor->vendorName; ?></small>
         </h2>
     </div>
 <?php endif; ?>
 
 <span style="float:left; font-weight:bold; width:650px;">
-    Displaying <?php echo $fromCalc; ?> to <?php echo $toCalc; ?> of <?php echo $totalRecords; ?> results
+    <?php echo _('Displaying') . ' ' . $fromCalc . ' ' . _('to') . ' ' . $toCalc . ' ' .  _('of') . ' ' . $totalRecords . ' ' . _('results'); ?>
 </span>
 
 <?php if ($totalRecords > $recordsPerPage): ?>

--- a/resources/templates/ebscoKbPackageList.php
+++ b/resources/templates/ebscoKbPackageList.php
@@ -21,7 +21,7 @@
             <td style="text-align: center;">
                 <?php if($item->resource): ?>
                     <a href="resource.php?resourceID=<?php echo $item->resource->primaryKey; ?>">
-                        <i class="fa fa-check text-success" title="imported in Coral"></i>
+                        <i class="fa fa-check text-success" title="<?php echo _('imported in Coral'); ?>"></i>
                     </a>
                 <?php endif; ?>
             </td>

--- a/resources/templates/ebscoKbTitleList.php
+++ b/resources/templates/ebscoKbTitleList.php
@@ -22,7 +22,7 @@
             <td style="text-align: center;">
                 <?php if($item->resource): ?>
                     <a href="resource.php?resourceID=<?php echo $item->resource->primaryKey; ?>">
-                        <i class="fa fa-check text-success" title="imported in Coral"></i>
+                        <i class="fa fa-check text-success" title="<?php echo _('imported in Coral'); ?>"></i>
                     </a>
                 <?php endif; ?>
             </td>


### PR DESCRIPTION
PR #334 introduced EBSCO KB integration.
However, a lot of strings brought by this development do not use gettext and are therefore not translatable.
This PR fixes this.

Please note that a few strings are still not translatable, but this requires further investigation on how to make them translatable, and this is beyond the scope of this PR (titleSearchFieldOptions, titleResourceTypeOptions, selectionOptions, and packageContentTypeOptions in admin/classes/domain/EbscoKbService.php )
