### PR TITLE
Allow to use OAuth for the ILS connector

### DIFF
--- a/organizations/admin/classes/api_client/INSTALL
+++ b/organizations/admin/classes/api_client/INSTALL
@@ -1,0 +1,2 @@
+Install Unirest in resources/api_client with composer, so autoload.php is available like this: resources/api_client/vendor/autoload.php
+If you plan to use OAuth, install league/oauth2-client also in resources/api_client with composer.

--- a/organizations/admin/classes/api_client/KohaClient.php
+++ b/organizations/admin/classes/api_client/KohaClient.php
@@ -11,13 +11,30 @@ class KohaClient implements ILSClient {
     private $api;
     private $coralToKohaKeys;
     private $kohaToCoralKeys;
+    private $config;
 
     function __construct() {
-        $config = new Configuration();
-        $this->server = $config->ils->ilsAdminUrl;
-        $this->api = $config->ils->ilsApiUrl;
+        $this->config = new Configuration();
+        $this->server = $this->config->ils->ilsAdminUrl;
+        $this->api = $this->config->ils->ilsApiUrl;
         $this->coralToKohaKeys = array("companyURL" => "url", "noteText" => "notes", "accountDetailText" => "accountnumber");
         $this->kohaToCoralKeys = array_flip($this->coralToKohaKeys);
+    }
+
+    /**
+     * Authenticate against OAuth if configured
+     * @param an array of existing headers
+     * @return array of headers with OAuth authentication header
+     */
+    private function authenticate($headers = array()) {
+        if ($this->config->ils->oauthid) {
+            $oauth = new OAuth();
+            $token = $oauth->getToken();
+            if ($token) {
+                $headers['Authorization: Bearer '] = $token;
+            }
+        }
+        return $headers;
     }
 
     /**
@@ -27,6 +44,7 @@ class KohaClient implements ILSClient {
      */
     function addVendor($vendor) {
         $headers = array("Accept" => "application/json");
+        $headers = $this->authenticate($headers);
         $body = Unirest\Request\Body::json($this->_vendorToKoha($vendor));
         $response = Unirest\Request::post($this->api . "/acquisitions/vendors", $headers, $body);
         return ($response->body->id) ? $response->body->id : null;
@@ -39,6 +57,7 @@ class KohaClient implements ILSClient {
      * @return key-value array with vendor description
      */
     function getVendor($id) {
+        $headers = $this->authenticate();
         $response = Unirest\Request::get($this->api . "/acquisitions/vendors/$id");
         return $this->_vendorToCoral((array) $response->body);
     }
@@ -49,7 +68,8 @@ class KohaClient implements ILSClient {
      * @return key-value array with vendor description
      */
     function getVendorByName($name) {
-        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?name=$name");
+        $headers = $this->authenticate();
+        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?name=$name", $headers);
         return $this->_vendorToCoral((array) $response->body);
     }
 
@@ -59,7 +79,8 @@ class KohaClient implements ILSClient {
      * @return key-value array with vendor description
      */
     function getVendorByExactName($name) {
-        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?exactname=$name");
+        $headers = $this->authenticate();
+        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?exactname=$name", $headers);
         return $this->_vendorToCoral((array) $response->body);
     }
 
@@ -69,6 +90,7 @@ class KohaClient implements ILSClient {
      * @return boolean
      */
     function vendorExists($name) {
+        $headers = $this->authenticate();
         $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?exactname=$name");
         return (count((array) $response->body) > 0) ? true : false;
     }

--- a/organizations/admin/classes/api_client/OAuth.php
+++ b/organizations/admin/classes/api_client/OAuth.php
@@ -1,0 +1,40 @@
+<?php
+
+require '../resources/api_client/vendor/autoload.php';
+
+class OAuth {
+
+    function __construct() {
+        $config = new Configuration();
+        $this->clientid = $config->ils->oauthid;
+        $this->clientsecret = $config->ils->oauthsecret;
+		$this->tokenURL = $config->ils->ilsApiUrl . "/oauth/token";
+		$this->authURL = $config->ils->ilsApiUrl . "/oauth/authorize";
+    }
+
+    function getToken() {
+		$provider = new \League\OAuth2\Client\Provider\GenericProvider([
+			'clientId'                => $this->clientid,
+			'clientSecret'            => $this->clientsecret,
+			'urlAuthorize'            => $this->authURL,
+			'urlAccessToken'          => $this->tokenURL,
+			'urlResourceOwnerDetails' => ''
+		]);
+		try {
+
+			// Try to get an access token using the client credentials grant.
+			$accessToken = $provider->getAccessToken('client_credentials');
+
+		} catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
+
+			// Failed to get the access token
+			exit($e->getMessage());
+
+		}
+		return $accessToken;
+    }
+
+}
+
+?>
+

--- a/organizations/admin/configuration_sample.ini
+++ b/organizations/admin/configuration_sample.ini
@@ -15,6 +15,9 @@ ilsConnector=koha
 ilsVendorRole="Vendor"
 ilsApiUrl="http://mykoha.tld/api/"
 ilsAdminUrl="http://pro.mykoha.tld/"
+# If you want to use OAuth:
+oauthid="coral"
+oauthsecret="secret"
 
 [database]
 type = "mysql"


### PR DESCRIPTION
PR #296 introduced vendors synchronization with an ILS.
This PR adds OAuth support to authenticate against the ILS API.

See:
https://oauth.net/
http://oauth2-client.thephpleague.com/
