### PR TITLE
Fix multiple issues with resource submission

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1395,6 +1395,14 @@ class Resource extends DatabaseObject {
 		$this->removeResource();
 	}
 
+    // Removes all resource acquisitions from this resource
+    public function removeResourceAcquisitions() {
+        $instance = new ResourceAcquisition();
+        foreach($this->getResourceAcquisitions() as $instance) {
+            $instance->removeResourceAcquisition();
+        }
+
+    }
 
 
 	//removes this resource
@@ -1404,12 +1412,7 @@ class Resource extends DatabaseObject {
 		$this->removeResourceOrganizations();
 		$this->removeAllSubjects();
 		$this->removeAllIsbnOrIssn();
-
-        $instance = new ResourceAcquisition();
-        foreach($this->getResourceAcquisitions() as $instance) {
-            $instance->removeResourceAcquisition();
-        }
-
+        $this->removeResourceAcquisitions();
 		$instance = new ExternalLogin();
 		foreach ($this->getExternalLogins() as $instance) {
 			$instance->delete();

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -366,7 +366,7 @@ class Resource extends DatabaseObject {
 
 		$query = "SELECT * FROM ResourceNote RN
 					WHERE entityID = '" . $this->resourceID . "'
-					AND noteTypeID = " . $noteType->getInitialNoteTypeID() . "
+					AND noteTypeID = '" . $noteType->getInitialNoteTypeID() . "'
 					ORDER BY noteTypeID desc LIMIT 0,1";
 
 

--- a/resources/ajax_forms/getNewResourceForm.php
+++ b/resources/ajax_forms/getNewResourceForm.php
@@ -7,6 +7,14 @@
 			$resource = new Resource();
 		}
 
+        // get resource acquisition for this resource 
+        // at this point, there are none (resource not saved yet)
+        // or only one (resource saved as draft)
+        if ($resource->resourceID) {
+            $resourceAcquisitions = $resource->getResourceAcquisitions();
+            $resourceAcquisition = $resourceAcquisitions[0];
+        }
+
 		//used for default currency
 		$config = new Configuration();
 
@@ -40,22 +48,6 @@
 		$costDetailsArray = array();
 		$costDetailsObj = new CostDetails();
 		$costDetailsArray = $costDetailsObj->allAsArray();
-
-		//get payments
-		$paymentArray = array();
-		if ($resourceID){
-			$sanitizedInstance = array();
-			$instance = new ResourcePayment();
-			foreach ($resource->getResourcePayments() as $instance) {
-				foreach (array_keys($instance->attributeNames) as $attributeName) {
-					$sanitizedInstance[$attributeName] = $instance->$attributeName;
-				}
-
-				$sanitizedInstance[$instance->primaryKeyName] = $instance->primaryKey;
-
-				array_push($paymentArray, $sanitizedInstance);
-			}
-		}
 
 		//get notes
 		if ($resourceID){
@@ -191,7 +183,7 @@
 
 					//set default
 					if ($resourceID){
-						if ($acquisitionType['acquisitionTypeID'] == $resource->acquisitionTypeID) $checked = 'checked'; else $checked = '';
+						if ($acquisitionType['acquisitionTypeID'] == $resourceAcquisition->acquisitionTypeID) $checked = 'checked'; else $checked = '';
 					}else{
 						if (strtoupper($acquisitionType['shortName']) == 'PAID') $checked = 'checked'; else $checked = '';
 					}

--- a/resources/ajax_processing/submitNewResource.php
+++ b/resources/ajax_processing/submitNewResource.php
@@ -56,6 +56,9 @@
 			$resourceID=$resource->primaryKey;
 
             // Create the default order
+            //first, remove existing order in case this was saved before
+            $resource->removeResourceAcquisitions();
+
             $resourceAcquisition = new ResourceAcquisition();
             $resourceAcquisition->resourceID = $resourceID;
 			$resourceAcquisition->acquisitionTypeID = $_POST['acquisitionTypeID'];


### PR DESCRIPTION
 - Don't create multiple orders when a resource is saved as draft before being submitted
  Test plan:
  
   - Before the fix: Create a resource. Save it as draft, validate the resource. Two default orders will be created instead of one. If you edit the resource as draft multiple times before validating it, multiple default orders will be created.
 
    - After the fix: Proceed as before. Check that only one default order has been created when the resource is validated.


 - Fix acquisitionType selection when editing a resource saved as draft
   Test plan: 
     - Before the fix: Create a resource with an acquisitionType. Save it as draft. Edit it as draft. The acquisitionType will not be selected in the form.
     - After the fix: Proceed as before. Check that the acquisitionType is selected when editing the resource as draft. Check that the acquisitionType is registered in the default order when the resource is validated.
 
- Remove dead code: a ResourcePayment array was created and never used.