### PR TITLE
Allow to close a modal popup with the escape key

### DIFF
--- a/resources/js/plugins/thickbox.js
+++ b/resources/js/plugins/thickbox.js
@@ -34,7 +34,6 @@ function tb_init(domChunk){
 }
 
 function tb_show(caption, url, imageGroup) {//function called when the user clicks on a thickbox link
-
 	try {
 		if (typeof document.body.style.maxHeight === "undefined") {//if IE 6
 			$("body","html").css({height: "100%", width: "100%"});
@@ -69,6 +68,28 @@ function tb_show(caption, url, imageGroup) {//function called when the user clic
 
 	   var urlString = /\.jpg$|\.jpeg$|\.png$|\.gif$|\.bmp$/;
 	   var urlType = baseURL.toLowerCase().match(urlString);
+
+        document.onkeydown = function(e){
+            if (e == null) { // ie
+                keycode = event.keyCode;
+            } else { // mozilla
+                keycode = e.which;
+            }
+            if(keycode == 27){ // close
+                tb_remove();
+            } else if(keycode == 190){ // display previous image
+                if(!(TB_NextHTML == "")){
+                    document.onkeydown = "";
+                    goNext();
+                }
+            } else if(keycode == 188){ // display next image
+                if(!(TB_PrevHTML == "")){
+                    document.onkeydown = "";
+                    goPrev();
+                }
+            }
+        };
+
 
 		if(urlType == '.jpg' || urlType == '.jpeg' || urlType == '.png' || urlType == '.gif' || urlType == '.bmp'){//code to show images
 
@@ -157,27 +178,6 @@ function tb_show(caption, url, imageGroup) {//function called when the user clic
 				$("#TB_next").click(goNext);
 
 			}
-
-			document.onkeydown = function(e){
-				if (e == null) { // ie
-					keycode = event.keyCode;
-				} else { // mozilla
-					keycode = e.which;
-				}
-				if(keycode == 27){ // close
-					tb_remove();
-				} else if(keycode == 190){ // display previous image
-					if(!(TB_NextHTML == "")){
-						document.onkeydown = "";
-						goNext();
-					}
-				} else if(keycode == 188){ // display next image
-					if(!(TB_PrevHTML == "")){
-						document.onkeydown = "";
-						goPrev();
-					}
-				}
-			};
 
 			tb_position();
 			$("#TB_load").remove();


### PR DESCRIPTION
Thickbox, which we use in Coral, and most of modal popup libraries, allow to close a modal popup with the escape key.
However, there is a bug in our modified version of thickbox that prevents this behaviour.

Test plan:
Before the fix: open a modal popup (new resource for example). You can't close the popup with the escape key.
After the fix: open a modal popup (new resource for example). You can close the popup with the escape key.
