### PR TITLE
#332 installer bug fix 

### DIFF
--- a/install/providers/have_database_access.php
+++ b/install/providers/have_database_access.php
@@ -84,7 +84,9 @@ function register_have_database_access_provider()
 					require "install/templates/database_details_template.php";
 					switch ($version) {
 						case Installer::VERSION_STRING_INSTALL:
-							$instruction = _("To begin with, we need a username and password to create the databases CORAL and its modules will be using.")
+							$instruction = _("CREATE DATABASES")
+                    . "<br/>"
+                    .  _("To create the databases CORAL will use, we need a mysql username and password with permission to create databases. This username and password will not be stored.")
 										. "<br />"
 										.  _("If you would like to use pre-existing databases or custom database names. Use the advanced section to configure these settings.");
 							$db_access_vars = array_intersect_key($db_access_vars, ["username" => 1, "password" => 1, "host" => 1]);

--- a/install/providers/have_database_access.php
+++ b/install/providers/have_database_access.php
@@ -84,13 +84,13 @@ function register_have_database_access_provider()
 					require "install/templates/database_details_template.php";
 					switch ($version) {
 						case Installer::VERSION_STRING_INSTALL:
-							$instruction = "<h4>"
+							$instruction = "<b>"
                     . _("Create Databases")
-                    . "</h4>"
+                    . "</b><br/>"
                     .  _("To create the databases CORAL will use, we need a mysql username and password with permission to create databases. This username and password will not be stored.")
-										. "<br /><br /><h5>"
+										. "<br /><br /><b>"
                     . _("Use Existing or Custom Databases")
-                    . "</h5>"
+                    . "</b><br/>"
 										.  _("If you would like to use pre-existing databases or custom database names. Use the advanced section to configure these settings.")
                     . "<br /><br />";
 							$db_access_vars = array_intersect_key($db_access_vars, ["username" => 1, "password" => 1, "host" => 1]);

--- a/install/providers/have_database_access.php
+++ b/install/providers/have_database_access.php
@@ -84,11 +84,15 @@ function register_have_database_access_provider()
 					require "install/templates/database_details_template.php";
 					switch ($version) {
 						case Installer::VERSION_STRING_INSTALL:
-							$instruction = _("CREATE DATABASES")
-                    . "<br/>"
+							$instruction = "<h4>"
+                    . _("Create Databases")
+                    . "</h4>"
                     .  _("To create the databases CORAL will use, we need a mysql username and password with permission to create databases. This username and password will not be stored.")
-										. "<br />"
-										.  _("If you would like to use pre-existing databases or custom database names. Use the advanced section to configure these settings.");
+										. "<br /><br /><h5>"
+                    . _("Use Existing or Custom Databases")
+                    . "</h5>"
+										.  _("If you would like to use pre-existing databases or custom database names. Use the advanced section to configure these settings.")
+                    . "<br /><br />";
 							$db_access_vars = array_intersect_key($db_access_vars, ["username" => 1, "password" => 1, "host" => 1]);
 							break;
 						default: // Upgrade

--- a/install/providers/have_default_db_user.php
+++ b/install/providers/have_default_db_user.php
@@ -139,7 +139,7 @@ function register_have_default_db_user_provider()
 								"uid" => "check_user_has_access_db_access",
 								"translatable_title" => sprintf(_("Check %s Has DB Access"), $default_db_username),
 								"post_installation" => true,
-								"bundle" => function($version = 0) use ($config_files, $testFileAccess, $fileACCESS) {
+                "bundle" => function($version = 0) use ($config_files, $db_info) {
 									return [
 										"function" => function($shared_module_info) use ($db_info, $failed_user_grants) {
 											$return = new stdClass();

--- a/organizations/install/protected/install.sql
+++ b/organizations/install/protected/install.sql
@@ -112,7 +112,6 @@ CREATE TABLE IF NOT EXISTS `Organization` (
   `companyURL` varchar(150) default NULL,
   `noteText` text,
   `accountDetailText` text,
-  `ebscoKbID` INT(11) DEFAULT NULL,
   PRIMARY KEY  (`organizationID`),
   UNIQUE KEY `organizationID` (`organizationID`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/resources/install/protected/install.sql
+++ b/resources/install/protected/install.sql
@@ -250,7 +250,6 @@ DROP TABLE IF EXISTS `Organization`;
 CREATE TABLE  `Organization` (
   `organizationID` int(10) unsigned NOT NULL auto_increment,
   `shortName` tinytext NOT NULL,
-  `ebscoKbID` INT(11) DEFAULT NULL,
   PRIMARY KEY  USING BTREE (`organizationID`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
@@ -331,7 +330,6 @@ CREATE TABLE  `Resource` (
   `catalogingStatusID` int(11) DEFAULT NULL,
   `coverageText` VARCHAR(1000) NULL DEFAULT NULL,
   `resourceAltURL` VARCHAR(2000) NULL DEFAULT NULL,
-  `ebscoKbID` INT(11) DEFAULT NULL,
   PRIMARY KEY  (`resourceID`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
This is supposed to fix the empty `$db_info` during the install process which resulted in error messages about '... denied from @ '  as reported #332 

It also attempts to improve the language used when asking for the user with database creation permissions to be more clear about what to expect. 

You can verify this by installing CORAL using a database user without permission to modify or create other users, so when it tries to create `coral_user` it will fail (silently, by the way, which is another issue I'll open shortly) and thus when it tries to use `coral_user` at the end of the process to actually run CORAL commands, you'll get 
<img width="716" alt="screen shot 2018-03-22 at 2 45 44 pm" src="https://user-images.githubusercontent.com/651304/37794530-bb7ce5b8-2ddf-11e8-8773-04cb60f75c43.png">

without this patch, and this 
<img width="1146" alt="screen shot 2018-03-22 at 2 39 33 pm" src="https://user-images.githubusercontent.com/651304/37794252-fef3fdb4-2dde-11e8-9228-968320eae55f.png">
with the patch. 


There is also an installation SQL issue error that I'm seeing

`Duplicate column name 'ebscoKbID'
For statement: ALTER TABLE 'Organization' ADD 'ebscoKbID' INT(11)`

But if you refresh the page you'll proceed past it. 

I will open a separate issue to get the installation sql and scripts updated to the 3.0 stage and make sure that there isn't duplicate SQL in the install and the updates, which is what appears to be causing that particular issue. 
