### PR TITLE
Issue 94: Allow ftp:// organization urls

### DIFF
--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -230,7 +230,9 @@ switch ($_GET['action']) {
 		if ($organization->companyURL){ ?>
 			<tr>
 			<td style='vertical-align:top;text-align:left;width:140px;'><?php echo _("Company URL:");?></td>
-			<td style='width:320px;'><a href='<?php echo $companyURL; ?>' target='_blank'><?php echo $organization->companyURL; ?></a></td>
+			<td style='width:320px; word-break: break-word;'>
+                <a href='<?php echo $companyURL; ?>' target='_blank' style="text-transform: none;"><?php echo $organization->companyURL; ?></a>
+            </td>
 			</tr>
 		<?php
 		}

--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -582,7 +582,7 @@ switch ($_GET['action']) {
 				<tr>
 				<td style='vertical-align:top;text-align:left;'><?php echo _("Login URL:");?></td>
 				<td style="word-break: break-all;"><?php echo $externalLogin['loginURL'];
-					if (strpos($externalLogin['loginURL'], '://') !== 0) {
+					if (strpos($externalLogin['loginURL'], '://') === false) {
 						$externalLogin['loginURL'] = "http://" . $externalLogin['loginURL'];
 					}
 				?>&nbsp;&nbsp;<a href='<?php echo $externalLogin['loginURL']; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt='<?php echo _("Visit Login URL");?>' title='<?php echo _("Visit Login URL");?>' style='vertical-align:top;'></a></td>

--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -230,7 +230,7 @@ switch ($_GET['action']) {
 		if ($organization->companyURL){ ?>
 			<tr>
 			<td style='vertical-align:top;text-align:left;width:140px;'><?php echo _("Company URL:");?></td>
-			<td style='width:320px; word-break: break-word;'>
+			<td style='width:320px; word-break: break-all;'>
                 <a href='<?php echo $companyURL; ?>' target='_blank' style="text-transform: none;"><?php echo $organization->companyURL; ?></a>
             </td>
 			</tr>
@@ -581,8 +581,8 @@ switch ($_GET['action']) {
 				<?php if ($externalLogin['loginURL']) { ?>
 				<tr>
 				<td style='vertical-align:top;text-align:left;'><?php echo _("Login URL:");?></td>
-				<td><?php echo $externalLogin['loginURL'];
-					if (strpos($externalLogin['loginURL'], 'http') !== 0) {
+				<td style="word-break: break-all;"><?php echo $externalLogin['loginURL'];
+					if (strpos($externalLogin['loginURL'], '://') !== 0) {
 						$externalLogin['loginURL'] = "http://" . $externalLogin['loginURL'];
 					}
 				?>&nbsp;&nbsp;<a href='<?php echo $externalLogin['loginURL']; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt='<?php echo _("Visit Login URL");?>' title='<?php echo _("Visit Login URL");?>' style='vertical-align:top;'></a></td>

--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -137,9 +137,9 @@ switch ($_GET['action']) {
 		$createUser = new User(new NamedArguments(array('primaryKey' => $organization->createLoginID)));
 		$updateUser = new User(new NamedArguments(array('primaryKey' => $organization->updateLoginID)));
 
-		//fix company url in case http is missing
+		//add http if protocol is missing
 		if ($organization->companyURL){
-			if (strpos(strtolower($organization->companyURL), 'http') === false){
+			if (strpos($organization->companyURL, '://') === false){
 				$companyURL = "http://" . $organization->companyURL;
 			}else{
 				$companyURL = $organization->companyURL;

--- a/organizations/summary.php
+++ b/organizations/summary.php
@@ -452,7 +452,7 @@ if ($organization->name){
 			<tr>
 			<td style='vertical-align:top;text-align:left;'><?php echo _("Login URL:");?></td>
 			<td style="word-break: break-all;"><?php echo $externalLogin['loginURL'];
-				if (strpos($externalLogin['loginURL'], '://') !== 0) {
+				if (strpos($externalLogin['loginURL'], '://') === false) {
 					$externalLogin['loginURL'] = "http://" . $externalLogin['loginURL'];
 				}
 			?>&nbsp;&nbsp;<a href='<?php echo $externalLogin['loginURL']; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt='<?php echo _("Visit Login URL");?>' title='<?php echo _("Visit Login URL");?>' style='vertical-align:top;'></a></td>

--- a/organizations/summary.php
+++ b/organizations/summary.php
@@ -68,7 +68,7 @@ if ($organization->name){
 
 		//fix company url in case http is missing
 		if ($organization->companyURL){
-			if (strpos(strtolower($organization->companyURL), 'http:') === false){
+			if (strpos($organization->companyURL, '://') === false){
 				$companyURL = "http://" . $organization->companyURL;
 			}else{
 				$companyURL = $organization->companyURL;
@@ -159,7 +159,7 @@ if ($organization->name){
 		if ($organization->companyURL){ ?>
 			<tr>
 			<td style='vertical-align:top;text-align:left;width:140px;'><?php echo _("Company URL:");?></td>
-			<td style='width:320px;'><a href='<?php echo $companyURL; ?>' target='_blank'><?php echo $organization->companyURL; ?></a></td>
+			<td style='width:320px; word-break: break-all;'><a href='<?php echo $companyURL; ?>' target='_blank'><?php echo $organization->companyURL; ?></a></td>
 			</tr>
 		<?php
 		}
@@ -451,8 +451,8 @@ if ($organization->name){
 			<?php if ($externalLogin['loginURL']) { ?>
 			<tr>
 			<td style='vertical-align:top;text-align:left;'><?php echo _("Login URL:");?></td>
-			<td><?php echo $externalLogin['loginURL']; 
-				if (strpos($externalLogin['loginURL'], 'http') !== 0) {
+			<td style="word-break: break-all;"><?php echo $externalLogin['loginURL'];
+				if (strpos($externalLogin['loginURL'], '://') !== 0) {
 					$externalLogin['loginURL'] = "http://" . $externalLogin['loginURL'];
 				}
 			?>&nbsp;&nbsp;<a href='<?php echo $externalLogin['loginURL']; ?>' target='_blank'><img src='images/arrow-up-right.gif' alt='<?php echo _("Visit Login URL");?>' title='<?php echo _("Visit Login URL");?>' style='vertical-align:top;'></a></td>


### PR DESCRIPTION
Fixes #94 

## Fix
Instead of searching for a missing `http` string, instead search for a missing protocol `://`
Additionally, added CSS to allow urls to wrap. Very long urls would bleed over to the helpful links section

## Testing
In the organizations module, add an ftp url as the company url or the login url (login url under Accounts).