### PR TITLE
Error 404 when trying to delete non-existent resource

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1399,9 +1399,6 @@ class Resource extends DatabaseObject {
 
 	//removes this resource
 	public function removeResource() {
-		if (empty($this->resourceID)) {
-			throw new Exception('Resource not found');
-		}
 		//delete data from child linked tables
 		$this->removeResourceRelationships();
 		$this->removeResourceOrganizations();

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -1399,6 +1399,9 @@ class Resource extends DatabaseObject {
 
 	//removes this resource
 	public function removeResource() {
+		if (empty($this->resourceID)) {
+			throw new Exception('Resource not found');
+		}
 		//delete data from child linked tables
 		$this->removeResourceRelationships();
 		$this->removeResourceOrganizations();

--- a/resources/ajax_processing/deleteResource.php
+++ b/resources/ajax_processing/deleteResource.php
@@ -6,6 +6,7 @@
 			$resource->removeResource();
 			echo _("Resource successfully deleted.");
 		} catch (Exception $e) {
-			echo $e->getMessage();
+            http_response_code(404);
+            echo _("Resource not found. Error: ".$e->getMessage());
 		}
 ?>

--- a/resources/ajax_processing/deleteResource.php
+++ b/resources/ajax_processing/deleteResource.php
@@ -7,6 +7,6 @@
 			echo _("Resource successfully deleted.");
 		} catch (Exception $e) {
             http_response_code(404);
-            echo _($e->getMessage());
+            echo _("Resource not found. Error: ".$e->getMessage());
 		}
 ?>

--- a/resources/ajax_processing/deleteResource.php
+++ b/resources/ajax_processing/deleteResource.php
@@ -7,6 +7,6 @@
 			echo _("Resource successfully deleted.");
 		} catch (Exception $e) {
             http_response_code(404);
-            echo _("Resource not found. Error: ".$e->getMessage());
+            echo _($e->getMessage());
 		}
 ?>


### PR DESCRIPTION
Fixes #93 

## Fix
Add php response code and resource not found error message

## Test
1. Create a resource
2. Get the resource id
3. Ping the delete resource url: some-domain/resources/ajax_processing.php?action=deleteResource&resourceID=`resourceID`
4. Should receive a `Resource successfully deleted` message and 200 response code
5. Ping the same url
6. Should receive a `Resource not found. Error: <db error message>` and 404 response code