### PR TITLE
Issues 103, 403: Fix selected language in dropdown when language cookie is not set.

### DIFF
--- a/LangCodes.php
+++ b/LangCodes.php
@@ -26,5 +26,9 @@ class LangCodes{
         );
         return array_key_exists($code_lang, $name_lang) ? $name_lang[$code_lang] : "English";
     }
+
+    public function getBrowserLanguage() {
+        return str_replace('-', '_', substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5));
+    }
 }
 ?>

--- a/auth/admin.php
+++ b/auth/admin.php
@@ -109,7 +109,7 @@ if (isset($user) && ($user->isAdmin) && ($user->getOpenSession())){
                 echo "<br>"._("Invalid translation route!"); 
             }
             // Get language of navigator
-            $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+            $defLang = $lang_name->getBrowserLanguage();
             
             // Show an ordered list
             sort($lang); 

--- a/auth/index.php
+++ b/auth/index.php
@@ -242,7 +242,7 @@ if(array_key_exists('admin', $_GET)){
                 echo "<br>"._("Invalid translation route!"); 
             }
             // Get language of navigator
-            $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+            $defLang = $lang_name->getBrowserLanguage();
             
             // Show an ordered list
             sort($lang); 

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
 	if(isset($_COOKIE["lang"])){
 		$http_lang = $_COOKIE["lang"];
 	}else{
-		$codeL = str_replace("-","_",substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5));
+		$codeL = $lang_name->getBrowserLanguage();
 		$http_lang = $lang_name->getLanguage($codeL);
 		if($http_lang == "")
 		  $http_lang = "en_US";
@@ -71,7 +71,7 @@
 					echo "<br>"._("Invalid translation route!");
 				}
 				// Get language of navigator
-				$defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+				$defLang = $lang_name->getBrowserLanguage();
 
 				// Show an ordered list
 				sort($lang);

--- a/licensing/templates/header.php
+++ b/licensing/templates/header.php
@@ -142,7 +142,7 @@ $coralURL = $util->getCORALURL();
                             echo "<br>"._("Invalid translation route!"); 
                         }
                         // Get language of navigator
-                        $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+                        $defLang = $lang_name->getBrowserLanguage();
                         
                         // Show an ordered list
                         sort($lang); 

--- a/management/templates/header.php
+++ b/management/templates/header.php
@@ -139,7 +139,7 @@ $coralURL = $util->getCORALURL();
                             echo "<br>"._("Invalid translation route!"); 
                         }
                         // Get language of navigator
-                        $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+                        $defLang = $lang_name->getBrowserLanguage();
                         
                         // Show an ordered list
                         sort($lang); 

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -133,7 +133,7 @@ $coralURL = $util->getCORALURL();
                             echo "<br>"._("Invalid translation route!"); 
                         }
                         // Get language of navigator
-                        $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+                        $defLang = $lang_name->getBrowserLanguage();
                         
                         // Show an ordered list
                         sort($lang); 

--- a/reports/index.php
+++ b/reports/index.php
@@ -60,7 +60,7 @@ include 'templates/header.php';
 				                echo "<br>"._("Invalid translation route!");
 				            }
 				            // Get language of navigator
-				            $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+				            $defLang = $lang_name->getBrowserLanguage();
 
 				            // Show an ordered list
 				            sort($lang);

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -131,7 +131,7 @@ $coralURL = $util->getCORALURL();
                             echo "<br>"._("Invalid translation route!"); 
                         }
                         // Get language of navigator
-                        $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+                        $defLang = $lang_name->getBrowserLanguage();
                         
                         // Show an ordered list
                         sort($lang); 

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -127,7 +127,7 @@ $coralURL = $util->getCORALURL();
                             echo "<br>"._("Invalid translation route!");
                         }
                         // Get language of navigator
-                        $defLang = substr($_SERVER["HTTP_ACCEPT_LANGUAGE"],0,5);
+                        $defLang = $lang_name->getBrowserLanguage();
 
                         // Show an ordered list
                         sort($lang);


### PR DESCRIPTION
PR Not found :)

Fixes issues #103 and #403 

Test plan:
 - Clear your Coral language cookie
 - Without changing language (no cookie set), check that the browser's language is selected by default in language dropdown lists everywhere in Coral.
 - Change the language (language cookie is set), check that the language you chose is selected in language dropdown lists everywhere in Coral.