### PR TITLE
Dashboards: align left panel and results table vertically

### DIFF
--- a/resources/ajax_htmldata/getDashboard.php
+++ b/resources/ajax_htmldata/getDashboard.php
@@ -16,7 +16,7 @@
     $query = $dashboard->getQuery($resourceTypeID, $year, $acquisitionTypeID, $orderTypeID, $subjectID, $costDetailsID, $groupBy);
     $results = $dashboard->getResults($query);
     if ($groupBy == "GS.shortName") $groupBy = "generalSubject";
-    echo "<table id='dashboard_table' class='dataTable' style='width:840px'>";
+    echo "<table id='dashboard_table' class='dataTable' style='width:840px;margin-top:0'>";
     echo "<thead><tr>";
     echo "<th>" . _("Name") . "</th>";
     echo "<th>" . _("Resource Type") . "</th>";

--- a/resources/ajax_htmldata/getDashboardYearlyCosts.php
+++ b/resources/ajax_htmldata/getDashboardYearlyCosts.php
@@ -23,7 +23,7 @@
     $costDetails = new CostDetails();
     $costDetailsArray = $costDetails->allAsArray();
 
-    echo "<table id='dashboard_table' class='dataTable' style='width:840px'>";
+    echo "<table id='dashboard_table' class='dataTable' style='width:840px;margin-top:0'>";
     echo "<thead><tr>";
     echo "<th>" . _("Name") . "</th>";
     echo "<th>" . _("Resource Type") . "</th>";

--- a/resources/dashboard.php
+++ b/resources/dashboard.php
@@ -13,7 +13,7 @@
 <tr style='vertical-align:top;'>
 <td style="width:155px;padding-right:10px;">
 <table class='noBorder' id='title-search'>
-	<tr><td style='text-align:left;width:75px;' align='left'>
+	<tr><td style='text-align:left;width:75px;vertical-align:top' align='left'>
 
 	<table class='borderedFormTable' style="width:150px">
 
@@ -80,7 +80,7 @@
     </table>
     </div>
  </td>
-<td>
+<td style="vertical-align:top">
 <div id="dashboardTable" />
 </td></tr>
 </table>

--- a/resources/dashboard_yearly_costs.php
+++ b/resources/dashboard_yearly_costs.php
@@ -12,7 +12,7 @@
 <tr style='vertical-align:top;'>
 <td style="width:155px;padding-right:10px;">
 <table class='noBorder' id='title-search'>
-    <tr><td style='text-align:left;width:75px;' align='left'>
+    <tr><td style='text-align:left;width:75px;vertical-align:top' align='left'>
 
     <table class='borderedFormTable' style="width:150px">
 
@@ -80,7 +80,7 @@
     </table>
     </div>
  </td>
-<td>
+<td style="vertical-align:top">
 <div id="dashboardTable" />
 </td></tr>
 </table>


### PR DESCRIPTION
The left panel is not visible in dashboards when there are too many results, because it is vertically centered. This patch aligns it vertically with the results table.

Before:
![before](https://user-images.githubusercontent.com/1679997/38724883-cd896362-3f05-11e8-8ca3-45304a9f196f.png)

After:
![after](https://user-images.githubusercontent.com/1679997/38724889-d153e756-3f05-11e8-89a9-d7eb0f2e588a.png)
