### PR TITLE
Capitalized resource_sidemenu links

### DIFF
--- a/resources/directory.php
+++ b/resources/directory.php
@@ -84,16 +84,16 @@ function watchString($string) {
 function resource_sidemenu($selected_link = '') {
   global $user;
   $links = array(
-    'product',
-    'orders',
-    'acquisitions',
-    'access',
-    'cataloging',
-    'contacts',
-    'accounts',
-    'issues',
-    'attachments',
-    'workflow',
+    'Product',
+    'Orders',
+    'Acquisitions',
+    'Access',
+    'Cataloging',
+    'Contacts',
+    'Accounts',
+    'Issues',
+    'Attachments',
+    'Workflow',
   );
 
   foreach ($links as $key) {


### PR DESCRIPTION
This is a bug fix for #423 

## Test Plan
Go to a resource record in English in the 3.0 beta release. The menu on the left will not be capitalized.

Apply this bug fix and reload the page. The menu on the left will be capitalized. 