### PR TITLE
Blank form in Resource Module and Fund List Dropdown not populating

### DIFF
--- a/resources/admin/classes/domain/Fund.php
+++ b/resources/admin/classes/domain/Fund.php
@@ -66,7 +66,7 @@ class Fund extends DatabaseObject {
 	//returns array of archived objects
 		public function getUnArchivedFunds(){
 
-		$query = "SELECT * FROM Fund WHERE archived is null ORDER BY 3";
+		$query = "SELECT * FROM Fund WHERE archived is null OR archived = 0 ORDER BY 3";
 				$result = $this->db->processQuery($query, 'assoc');
 
 				$resultArray = array();

--- a/resources/js/resource.js
+++ b/resources/js/resource.js
@@ -878,7 +878,7 @@ function bind_removes(){
              url:        "ajax_processing.php",
              cache:      false,
              data:       "action=deleteOrder&resourceAcquisitionID=" + $(this).attr("id"),
-             success:    function(html, ) {
+             success:    function(html) {
                  //post return message to index
                 postwith('resource.php?resourceID=' + $("#resourceID").val(), {message:html});
              }


### PR DESCRIPTION
Fix blank panes in Resource detail page found with Firefox (version 38.3 though very old)

Fix blank fund list  or newly added missing in fund list in Edit Cost From, for the Fund class' method  getUnArchivedFunds can only handle NULL value but not "0" of the archived field of the Fund table.
![image](https://user-images.githubusercontent.com/11461564/40251947-5d27e560-5aa0-11e8-94ed-e3ac22b3bfa4.png)
![image](https://user-images.githubusercontent.com/11461564/40251965-6d26330e-5aa0-11e8-9e5c-9480c79bcea4.png)
