### PR TITLE
Add an option to save import configuration on the fly

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -2814,6 +2814,19 @@ img.remove {
     padding-bottom: 5px;
 }
 
+#saveCurrentMappingDiv fieldset legend {
+	padding: 0 5px;
+	font-weight: bold;
+	width: initial;
+}
+
+#saveCurrentMappingDiv fieldset {
+	border: solid 1px #ccc;
+    margin-left: 25px;
+    margin-right: 25px;
+    padding-bottom: 10px;
+}
+
 #importConfigColumns fieldset legend {
 	padding: 0 5px;
 	font-weight: bold;

--- a/resources/import.php
+++ b/resources/import.php
@@ -205,6 +205,13 @@
 			<div id='configDiv'>
 				<?php include 'ajax_forms/getImportConfigForm.php';?>
 			</div>
+            <div id="saveCurrentMappingDiv">
+                <fieldset><legend><?php echo _('Save current mapping'); ?></legend>
+                <label for="saveName"><?php echo _("Configuration name:"); ?> </label> <input type="text" name="saveName" id="saveName" /> <input type="button" id="saveConfiguration" value="<?php echo _("Save configuration"); ?>" /><br /><br />
+                <div id='saveDiv'></div>
+                </fieldset>
+            </div>
+
 <?php
 			print "<input type=\"hidden\" name=\"delimiter\" value=\"$delimiter\" />";
 			print "<input type=\"hidden\" name=\"uploadfile\" value=\"$uploadfile\" />";
@@ -214,7 +221,25 @@
 
 
 			<script type='text/javascript'>
-				$('#config_form').submit(function () {
+                $('#saveConfiguration').click(function() {
+                    if ($('#saveName').val().trim() == '') {
+                        $("#saveDiv").html('<?php echo _("Configuration name cannot be empty"); ?>');
+                    } else {
+                        var currentConfig = createJsonFromPage();
+                        $.ajax({
+                            type:       "POST",
+                            url:        "ajax_processing.php?action=updateImportConfig",
+                            cache:      false,
+                            data:       { shortName: $('#saveName').val(), configuration: currentConfig['configuration'], orgNameImported: currentConfig['orgNameImported'], orgNameMapped: currentConfig['orgNameMapped']},
+                            success:    function(html) {
+                                $("#saveDiv").html(html == '' ? '<?php echo _('The import configuration has been successfully saved.'); ?>' : '<?php echo _('The import configuration could not be saved: '); ?>' + html);
+                            }
+                        });
+                    }
+                });
+                $('#config_form').submit(function() { createJsonFromPage() });
+
+                function createJsonFromPage() {
 			        var jsonData = {};
 				jsonData.configID = $('#importConfiguration').val();
 			        jsonData.title = $('#resource_titleCol').val();
@@ -246,6 +271,9 @@
 			        jsonData.acquisitionType = $("#acquisition_type").val();
 			        jsonData.fundCode = $("#fundCode").val();
 			        jsonData.cost = $("#cost").val();
+                    jsonData.currencyCode = $("#currency").val();
+                    jsonData.orderTypeID = $("#orderType").val();
+                    jsonData.sendemails = $("#sendemails").attr('checked');
 
 			        jsonData.subject = [];
 			        $('div.subject-record').each(function() {
@@ -300,7 +328,13 @@
 			        newinput.type = "hidden";
 			        newinput.value = orgNameMapped;
 			        document.getElementById("config_form").appendChild(newinput);
-				});
+
+                    var currentConfig = Object();
+                    currentConfig['configuration'] = configuration;
+                    currentConfig['orgNameImported'] = orgNameImported;
+                    currentConfig['orgNameMapped'] = orgNameMapped;
+                    return currentConfig;
+                }
 			</script>
 <?php
 		}


### PR DESCRIPTION
This patch allows to save an import configuration on the import page, allowing to create/edit configurations during the import process.

![savemapping1](https://user-images.githubusercontent.com/1679997/41405866-201cf224-6fcb-11e8-8930-63058530c6b4.png)
![mapping2](https://user-images.githubusercontent.com/1679997/41405871-238e83be-6fcb-11e8-8a46-be331435720a.png)
![mapping3](https://user-images.githubusercontent.com/1679997/41405876-25734fb6-6fcb-11e8-8c97-b9a9cf0c8c28.png)


Also, bug fix: currency, orderType and sendemails attributes were not properly
transmitted through import process

Test plans:
Create a new config:
 - Start an import
 - Create a configuration
 - Save current configuration
 - Check in admin -> Import Configuration that the configuration has been added

Edit an existing configuration and save it as new:
 - Start an import
 - Load an existing configuration
 - Edit it
 - Save it with a new name
 - Check in admin -> Import Configuration that the configuration has been added