### PR TITLE
Allow to disable alerts on orders

### DIFF
--- a/resources/ajax_processing/submitAcquisitions.php
+++ b/resources/ajax_processing/submitAcquisitions.php
@@ -24,7 +24,7 @@
 		$resourceAcquisition->acquisitionTypeID 				= $_POST['acquisitionTypeID'];
 		$resourceAcquisition->orderNumber 						= $_POST['orderNumber'];
 		$resourceAcquisition->systemNumber 					= $_POST['systemNumber'];
-		$resourceAcquisition->subscriptionAlertEnabledInd 		= isset($_POST['subscriptionAlertEnabledInd']) ? $_POST['subscriptionAlertEnabledInd'] : null;
+		$resourceAcquisition->subscriptionAlertEnabledInd 		= isset($_POST['subscriptionAlertEnabledInd']) ? $_POST['subscriptionAlertEnabledInd'] : 0;
 		$resourceAcquisition->resourceID 		= $_POST['resourceID'];
 		$resourceAcquisition->organizationID    = $_POST['organizationID'];
 


### PR DESCRIPTION
Once alerts are enabled on orders, they cannot be disabled again. This patch allows to disable alerts on orders.