### PR TITLE
Removed "Accounts" entry from Resources menu

### DIFF
--- a/resources/directory.php
+++ b/resources/directory.php
@@ -90,7 +90,6 @@ function resource_sidemenu($selected_link = '') {
     'Access',
     'Cataloging',
     'Contacts',
-    'Accounts',
     'Issues',
     'Attachments',
     'Workflow',


### PR DESCRIPTION
Since I don't see the Accounts menu in 2.0.1 or when it's lowercase, I'm proposing we solve #439 by removing that entry from the menu. 