### PR TITLE
Issue 446: Fix end date alert

### DIFF
--- a/resources/admin/classes/domain/AlertDaysInAdvance.php
+++ b/resources/admin/classes/domain/AlertDaysInAdvance.php
@@ -28,10 +28,9 @@ class AlertDaysInAdvance extends DatabaseObject {
 	public function getResourcesToAlert(){
 
 
-		$query = "SELECT DISTINCT resourceID
-					FROM Resource
-					WHERE ((DATE_SUB(currentEndDate, INTERVAL " . $this->daysInAdvanceNumber . " DAY) = CURDATE()) OR
-					(currentEndDate = CURDATE()))
+		$query = "SELECT DISTINCT R.resourceID from Resource R LEFT JOIN ResourceAcquisition RA ON RA.resourceID = R.resourceID
+					WHERE ((DATE_SUB(subscriptionEndDate, INTERVAL " . $this->daysInAdvanceNumber . " DAY) = CURDATE()) OR
+					(subscriptionEndDate = CURDATE()))
 					AND subscriptionAlertEnabledInd = '1'";
 
 


### PR DESCRIPTION
Fix for issue #446 : Missing Field in coral_resources.Resources

Test plan:
  * Add an email in admin -> Alert Settings
  * set an end date for an order that matches a "Days in advance of expiration" in admin -> Alert Settings.
  * call the sendAlerts script: `wget -O - http://coral.local/resources/sendAlerts.php`
  * Check that you received an alert email.



