### PR TITLE
(issue #448) Can't switch language if Coral runs on a non-standard port

### DIFF
--- a/auth/admin.php
+++ b/auth/admin.php
@@ -158,7 +158,7 @@ if (isset($user) && ($user->isAdmin) && ($user->getOpenSession())){
         var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
         time += cookievalid;
         now.setTime(time);
-        document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+        document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
     }
 </script>
 <script type="text/javascript" src="js/admin.js"></script>

--- a/auth/index.php
+++ b/auth/index.php
@@ -290,7 +290,7 @@ if(array_key_exists('admin', $_GET)){
             var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
             time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 	    }
     </script>
 <script type="text/javascript">

--- a/index.php
+++ b/index.php
@@ -145,7 +145,7 @@
 			var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
 			time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 		}
 	</script>
 </body>

--- a/licensing/templates/header.php
+++ b/licensing/templates/header.php
@@ -390,7 +390,7 @@ if ((file_exists($util->getCORALPath() . "index.php")) || ($config->settings->or
             var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
             time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 	    }
     </script>
 <span id='span_message' style='color:red;text-align:left;'><?php if (isset($err)) echo $err; ?></span>

--- a/management/templates/header.php
+++ b/management/templates/header.php
@@ -325,7 +325,7 @@ if ((file_exists($util->getCORALPath() . "index.php")) || ($config->settings->or
             var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
             time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 	    }
     </script>
 <span id='span_message' style='color:red;text-align:left;'><?php if (isset($err)) echo $err; ?></span>

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -299,7 +299,7 @@ if ((file_exists($util->getCORALPath() . "index.php")) || ($config->settings->li
                 var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
                 time += cookievalid;
                 now.setTime(time);
-                document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+                document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
             }
         </script>
 <span id='span_message' style='color:red;text-align:left;'><?php if (isset($_POST['message'])) echo $_POST['message']; if (isset($errorMessage)) echo $errorMessage; ?></span>

--- a/reports/index.php
+++ b/reports/index.php
@@ -172,7 +172,7 @@ ob_end_flush();
         var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
         time += cookievalid;
 		now.setTime(time);
-		document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+		document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
     }
 </script>
 

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -283,7 +283,7 @@ if ((file_exists($util->getCORALPath() . "index.php")) || ($config->settings->li
             var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
             time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 	    }
     </script>
 <span id='span_message' class='darkRedText' style='text-align:left;'><?php if (isset($_POST['message'])) echo $_POST['message']; if (isset($errorMessage)) echo $errorMessage; ?></span>

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -313,7 +313,7 @@ if ((file_exists($util->getCORALPath() . "index.php")) || ($config->settings->or
             var cookievalid=2592000000; // 30 days (1000*60*60*24*30)
             time += cookievalid;
 			now.setTime(time);
-			document.cookie ='lang='+lang+';path=/'+';domain='+wl.host+';expires='+now;
+			document.cookie ='lang='+lang+';path=/'+';domain='+wl.hostname+';expires='+now;
 	    }
     </script>
 <span id='span_message' style='color:red;text-align:left;'><?php if (isset($err)) echo $err; ?></span>


### PR DESCRIPTION
When running Coral on a non-standard port, for example :9090,
switching the language from English to another is not possible.
When choosing another language from the pull down, the page
reloads and jumps back to English instead of the language chosen.

This is because the lang cookie storing the selected language isn't set.

After some research the problem is that Coral tries to set the
domain attribute of the cookie to the host including the port
number. Instead it should be using the host name without the port.

Cookies do not provide isolation by port. If a cookie is readable
by a service running on one port, the cookie is also readable
by a service running on another port of the same server...
(https://tools.ietf.org/html/rfc6265#section-5.1.3)

Test plan:
- Configure Coral to run on another port, like 9090
- Try to switch to another language than English from different modules and pages
- Check that no lang cookie is stored
- Apply the patch
- Repeat the test plan and verify that the cookie is now
  set properly and switching the language works as expected