### PR TITLE
Fix access method deletion in admin

### DIFF
--- a/resources/admin/classes/domain/AccessMethod.php
+++ b/resources/admin/classes/domain/AccessMethod.php
@@ -28,7 +28,7 @@ class AccessMethod extends DatabaseObject {
 	//returns number of children for this particular contact role
 	public function getNumberOfChildren(){
 
-		$query = "SELECT count(*) childCount FROM Resource WHERE accessMethodID = '" . $this->accessMethodID . "';";
+		$query = "SELECT count(*) childCount FROM ResourceAcquisition WHERE accessMethodID = '" . $this->accessMethodID . "';";
 
 		$result = $this->db->processQuery($query, 'assoc');
 


### PR DESCRIPTION
Test plan:

1) On master or development branch, try to delete an unused access method in admin. The access method cannot be deleted.
2) Apply the PR
3) Try to delete an unused access method in admin. The unused access method can be deleted. Check that a used access method cannot be deleted.