### PR TITLE
OAuth authentication: bugfix and enhancements

### DIFF
--- a/organizations/admin/classes/api_client/KohaClient.php
+++ b/organizations/admin/classes/api_client/KohaClient.php
@@ -117,7 +117,7 @@ class KohaClient implements ILSClient {
      */
     function _checkForError($response) {
         $body = (array) $response->body;
-        if ($body['error']) {
+        if (array_key_exists("error", $body)) {
             return $body['error'];
         }
         return null;

--- a/organizations/admin/classes/api_client/KohaClient.php
+++ b/organizations/admin/classes/api_client/KohaClient.php
@@ -74,24 +74,13 @@ class KohaClient implements ILSClient {
     }
 
     /**
-     * Gets a vendor from the ILS
-     * @param name of the vendor in the ils
-     * @return key-value array with vendor description
-     */
-    function getVendorByExactName($name) {
-        $headers = $this->authenticate();
-        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?exactname=$name", $headers);
-        return $this->_vendorToCoral((array) $response->body);
-    }
-
-    /**
      * Does a vendor exist in the ILS?
      * @param name of the vendor in the ils
      * @return boolean
      */
     function vendorExists($name) {
         $headers = $this->authenticate();
-        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?exactname=$name");
+        $response = Unirest\Request::get($this->api . "/acquisitions/vendors/?name=$name");
         return (count((array) $response->body) > 0) ? true : false;
     }
 

--- a/organizations/admin/classes/api_client/OAuth.php
+++ b/organizations/admin/classes/api_client/OAuth.php
@@ -20,17 +20,30 @@ class OAuth {
 			'urlAccessToken'          => $this->tokenURL,
 			'urlResourceOwnerDetails' => ''
 		]);
-		try {
+        if (!array_key_exists("oauthToken", $_SESSION)) {
+            try {
 
-			// Try to get an access token using the client credentials grant.
-			$accessToken = $provider->getAccessToken('client_credentials');
+                // Try to get an access token using the client credentials grant.
+                $accessToken = $provider->getAccessToken('client_credentials');
 
-		} catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
+            } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
 
-			// Failed to get the access token
-			exit($e->getMessage());
+                // Failed to get the access token
+                exit($e->getMessage());
 
-		}
+            }
+        } else {
+            $existingAccessToken = unserialize($_SESSION['oauthToken']);
+            if ($existingAccessToken->hasExpired()) {
+                $newAccessToken = $provider->getAccessToken('refresh_token', [
+                    'refresh_token' => $existingAccessToken->getRefreshToken()
+                ]);
+                $accessToken = $newAccessToken;
+            } else {
+                $accessToken = $existingAccessToken;
+            }
+        }
+        $_SESSION['oauthToken'] = serialize($accessToken);
 		return $accessToken;
     }
 

--- a/organizations/admin/interfaces/ILSClient.php
+++ b/organizations/admin/interfaces/ILSClient.php
@@ -4,7 +4,6 @@ interface ILSClient {
     function addVendor($vendor);
     function getVendor($id);
     function getVendorByName($name);
-    function getVendorByExactName($name);
     function vendorExists($name);
     function getILSName();
     function getILSURL();

--- a/organizations/ajax_processing.php
+++ b/organizations/ajax_processing.php
@@ -98,7 +98,6 @@ switch ($_GET['action']) {
                                                 "companyURL" => $organization->companyURL,
                                                 "noteText" => $organization->noteText,
                                                 "accountDetailText" => $organization->accountDetailText,
-                                                "coralID" => (int) $organization->organizationID,
                                                 )
                                             );
                     if ($ilsID) {

--- a/organizations/ajax_processing.php
+++ b/organizations/ajax_processing.php
@@ -573,13 +573,10 @@ switch ($_GET['action']) {
         $exists = -1;
         if ($config->ils->ilsConnector) {
             $ilsClient = (new ILSClientSelector())->select();
-            if ($name && $ilsClient->vendorExists($name)) {
-                $exists = 1;
-            } else {
-                $exists = 0;
+            if ($name) {
+                echo $ilsClient->vendorExists($name);
             }
         }
-        echo $exists;
         break;
 
     default:

--- a/organizations/js/forms/organizationSubmitForm.js
+++ b/organizations/js/forms/organizationSubmitForm.js
@@ -72,9 +72,11 @@ $(function(){
                     $("#ils_span").html(_("This vendor does not exist in the ILS."));
                     $("#retrieveVendor").hide();
                     $("#submitOrganizationChanges").removeAttr("disabled");
-                }else{
+                } else if (exists == 1) {
                     $("#ils_span").html(_("This vendor exists in the ILS."));
                     $("#retrieveVendor").show();
+                }else {
+                    $("#ils_span").html(_("Something went wrong: ") + exists);
                 }
              }
           });

--- a/resources/api_client/composer.json
+++ b/resources/api_client/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
-        "mashape/unirest-php": "2.*"
+        "mashape/unirest-php": "2.*",
+        "league/oauth2-client": "2.*"
     }
 }

--- a/resources/api_client/composer.json
+++ b/resources/api_client/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "mashape/unirest-php": "2.*",
+        "mashape/unirest-php": "3.*",
         "league/oauth2-client": "2.*"
     }
 }


### PR DESCRIPTION
This patch provides a bugfix and several enhancements for OAuth authentication in the Koha connector:
  - Fix incorrect use of "Authorization" header.
  - Add better error handling
  - Authentication token is now stored in session and re-used until expired.
  - Replace incorrect call to Koha API.

Test plan:
Koha version >= 18.05 needed.
  - Coral: Install Unirest and league/oauth2-client in resources/api_client (composer might be the easiest way to do it)
  - Koha: Install Net::OAuth2::AuthorizationServer and enable RESTOAuth2ClientCredentials syspref.
  - Koha: Create a user for the REST API, edit this user, click on more -> manage API Keys -> Generate new client id/secret pair
  - Coral: edit organizations/admin/configuration.ini as such:
```
[ils]
ilsConnector=koha
ilsVendorRole="Vendor"
ilsApiUrl="http://yourkoha.tld/api/v1"
ilsAdminUrl="http://admin.yourkoha.tld/"
oauthid="<paste Client ID generated in Koha>"
oauthsecret="<paste Secret generated in Koha>"

```
  - Check that you can synchronize vendors between Coral and Koha (see http://docs.coral-erm.org/en/latest/integration.html and/or https://github.com/coral-erm/coral/pull/296 for explanations and screenshots) or that you get an error message if something went wrong.