### PR TITLE
Improvements to the order dropdown list

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -108,7 +108,7 @@ class Resource extends DatabaseObject {
     }
 
     public function getResourceAcquisitions() {
-        $query = "SELECT * from ResourceAcquisition WHERE resourceID = " . $this->resourceID;
+        $query = "SELECT * from ResourceAcquisition WHERE resourceID = " . $this->resourceID . " ORDER BY subscriptionStartDate DESC, subscriptionEndDate DESC";
 		$result = $this->db->processQuery($query, 'assoc');
         $objects = array();
 

--- a/resources/admin/classes/domain/ResourceAcquisition.php
+++ b/resources/admin/classes/domain/ResourceAcquisition.php
@@ -986,7 +986,14 @@ class ResourceAcquisition extends DatabaseObject {
 		return $objects;
 	}
 
-
+    // Returns true if today is between the order's subscription start date and end date
+    // Returns false otherwise
+    public function isActiveToday() {
+        $start = new DateTime($this->subscriptionStartDate);
+        $end = new DateTime($this->subscriptionEndDate);
+        $now = new DateTime(date("Y-m-d"));
+        return ($start <= $now && $end >= $now) ? true : false;
+    }
 
 }
 

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -3243,3 +3243,12 @@ input#archiveInd {
 	margin-top: 0px !important;
 	overflow-x: hidden !important;
 }
+
+#resourceAcquisitionSelect {
+    max-width: 1000px;
+}
+
+#resourceAcquisitionSelectDiv {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}

--- a/resources/resource.php
+++ b/resources/resource.php
@@ -51,19 +51,33 @@ if ($resource->titleText){
 	<td style='margin:0;padding:0;text-align:left;'>
 
 		<div style='vertical-align:top; width:100%; height:35px; margin-left:5px;padding:0;'>
-			<span class="headerText" id='span_resourceName' style='float:left;vertical-align:text-top;'><?php echo $resource->titleText; ?>&nbsp;</span>
+			<span class="headerText" id='span_resourceName' style='vertical-align:text-top;'><?php echo $resource->titleText; ?>&nbsp;</span>
             <?php
                 if ($resource->countResourceAcquisitions() > 1) {
             ?>
-            <label for="resourceAcquisitionSelect">Order: </label>
+            <div id="resourceAcquisitionSelectDiv">
+            <label for="resourceAcquisitionSelect">Order:&nbsp;</label>
             <select id="resourceAcquisitionSelect">
             <?php
+                    $selected = false;
                     foreach ($resourceAcquisitions as $resourceAcquisition) {
                         echo "<option value=\"$resourceAcquisition->resourceAcquisitionID\"";
-                        if ($resourceAcquisitionID == $resourceAcquisition->resourceAcquisitionID) echo " selected=\"selected\"";
-                        echo ">$resourceAcquisition->subscriptionStartDate - $resourceAcquisition->subscriptionEndDate</option>";
+                        if (!$selected) {
+                            if ($resourceAcquisitionID == $resourceAcquisition->resourceAcquisitionID ||
+                                (!$resourceAcquisitionID && $resourceAcquisition->isActiveToday())) {
+                                    $selected = true;
+                                    echo " selected=\"selected\"";
+                            }
+                        }
+                        echo ">$resourceAcquisition->subscriptionStartDate - $resourceAcquisition->subscriptionEndDate";
+                        $organization = $resourceAcquisition->getOrganization();
+                        if ($organization) {
+                            echo " - " . $organization['organization'];
+                        }
+                        echo "</option>";
                     }
                     echo "</select>";
+                    echo ("</div>");
                 } else {
                     echo '<input type="hidden" id="resourceAcquisitionSelect" value="'.$resourceAcquisitions[0]->resourceAcquisitionID .'" />';
                 }


### PR DESCRIPTION
 - Sort orders by subscription start date desc, subscription end date desc
 - Select the first order that is currently active (start date <= today => end date)
 - Show the order's organization after the dates

Before:
![orders_before](https://user-images.githubusercontent.com/1679997/46956192-fe00c280-d094-11e8-845d-55091686bf55.png)

After:
![orders_after](https://user-images.githubusercontent.com/1679997/46956195-ffca8600-d094-11e8-8cf6-3902cee65141.png)
