### PR TITLE
Issue 478: Allow subscription start and end date to be null

### DIFF
--- a/resources/admin/classes/domain/ResourceAcquisition.php
+++ b/resources/admin/classes/domain/ResourceAcquisition.php
@@ -998,7 +998,16 @@ class ResourceAcquisition extends DatabaseObject {
         $start = new DateTime($this->subscriptionStartDate);
         $end = new DateTime($this->subscriptionEndDate);
         $now = new DateTime(date("Y-m-d"));
-        return ($start <= $now && $end >= $now) ? true : false;
+        if ($this->subscriptionStartDate && $this->subscriptionEndDate) {
+            return ($start <= $now && $end >= $now) ? true : false;
+        }
+        if ($this->subscriptionStartDate && !$this->subscriptionEndDate) {
+            return ($start <= $now) ? true : false;
+        }
+        if (!$this->subscriptionStartDate && $this->subscriptionEndDate) {
+            return ($end >= $now) ? true : false;
+        }
+        return false;
     }
 
 }

--- a/resources/ajax_processing/submitAcquisitions.php
+++ b/resources/ajax_processing/submitAcquisitions.php
@@ -11,14 +11,14 @@
 		if ((isset($_POST['currentStartDate'])) && ($_POST['currentStartDate'] != '')){
 			$resourceAcquisition->subscriptionStartDate = date("Y-m-d", strtotime($_POST['currentStartDate']));
 		}else{
-			$resourceAcquisition->subscriptionStartDate= date("Y-m-d");
+			$resourceAcquisition->subscriptionStartDate = '';
 		}
 
 		//first set current end Date for proper saving
 		if ((isset($_POST['currentEndDate'])) && ($_POST['currentEndDate'] != '')){
 			$resourceAcquisition->subscriptionEndDate = date("Y-m-d", strtotime($_POST['currentEndDate']));
 		}else{
-			$resourceAcquisition->subscriptionEndDate= date("Y-m-d");
+			$resourceAcquisition->subscriptionEndDate = '';
 		}
 
 		$resourceAcquisition->acquisitionTypeID 				= $_POST['acquisitionTypeID'];

--- a/resources/install/protected/3.0.1/001-478.sql
+++ b/resources/install/protected/3.0.1/001-478.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ResourceAcquisition MODIFY COLUMN subscriptionStartDate date NULL;
+ALTER TABLE ResourceAcquisition MODIFY COLUMN subscriptionEndDate date NULL;

--- a/resources/resource.php
+++ b/resources/resource.php
@@ -69,7 +69,16 @@ if ($resource->titleText){
                                     echo " selected=\"selected\"";
                             }
                         }
-                        echo ">$resourceAcquisition->subscriptionStartDate - $resourceAcquisition->subscriptionEndDate";
+                        echo ">";
+                        if ($resourceAcquisition->subscriptionStartDate && $resourceAcquisition->subscriptionEndDate) {
+                            echo "$resourceAcquisition->subscriptionStartDate - $resourceAcquisition->subscriptionEndDate";
+                        } elseif ($resourceAcquisition->subscriptionStartDate) {
+                            echo _("Start date") . ": " . $resourceAcquisition->subscriptionStartDate;
+                        } elseif ($resourceAcquisition->subscriptionEndDate) {
+                            echo _("End date") . ": " . $resourceAcquisition->subscriptionEndDate;
+                        } else {
+                            echo _("Order") . " " . $resourceAcquisition->resourceAcquisitionID;
+                        }
                         $organization = $resourceAcquisition->getOrganization();
                         if ($organization) {
                             echo " - " . $organization['organization'];


### PR DESCRIPTION
Fix for #478 

Test plan:
  - apply resources/install/protected/3.0.1/001-478.sql
  - Check that you can unset an order subscription start date
  - Check that you can unset an order subscription end date
  - Check that you can unset both
  - Check that the display is correct in the order dropdown list
  - Check that the active order is correctly selected

![issue_478](https://user-images.githubusercontent.com/1679997/47560183-d670ec00-d917-11e8-80ea-f0906b96a4ba.png)

When both dates are unset, the order id is displayed, so the user can differentiate the orders.
