### PR TITLE
Allow to specify date format in common/configuration.ini

### DIFF
--- a/common/common_directory.php
+++ b/common/common_directory.php
@@ -76,8 +76,14 @@ function format_date($mysqlDate) {
 	//make sure digit years matches for both directory.php and common.js
 
 	//SUGGESTED: "m/d/Y" or "d-m-Y"
-
-	return date("m/d/Y", strtotime($mysqlDate));
+    $config = new Configuration();
+    $config_date_format = $config->settings->date_format;
+    if (isset($config_date_format) && $config_date_format != '') {
+        $date_format = $config_date_format;
+    } else {
+        $date_format = "m/d/Y";
+    }
+    return date($date_format, strtotime($mysqlDate));
 
 }
 

--- a/common/common_directory.php
+++ b/common/common_directory.php
@@ -63,27 +63,27 @@ if(function_exists("date_default_timezone_set") and function_exists("date_defaul
 	@date_default_timezone_set(@date_default_timezone_get());
 }
 
+function return_date_format() {
+    $config = new Configuration();
+    $config_date_format = $config->settings->date_format;
+    if (isset($config_date_format) && $config_date_format != '') {
+        $date_format = $config_date_format;
+    } else {
+        $date_format = "%m/%d/%Y";
+    }
+    return $date_format;
+}
 
 function format_date($mysqlDate) {
 
 	//see http://php.net/manual/en/function.date.php for options
-
-	//there is a dependence on strtotime recognizing date format for date inputs
-	//thus, european format (d-m-Y) must use dashes rather than slashes
 
 	//upper case Y = four digit year
 	//lower case y = two digit year
 	//make sure digit years matches for both directory.php and common.js
 
 	//SUGGESTED: "m/d/Y" or "d-m-Y"
-    $config = new Configuration();
-    $config_date_format = $config->settings->date_format;
-    if (isset($config_date_format) && $config_date_format != '') {
-        $date_format = $config_date_format;
-    } else {
-        $date_format = "m/d/Y";
-    }
-    return date($date_format, strtotime($mysqlDate));
+    return strftime(return_date_format(), strtotime($mysqlDate));
 
 }
 

--- a/common/configuration_sample.ini
+++ b/common/configuration_sample.ini
@@ -52,3 +52,7 @@ installed = "Y"
 [usage]
 enabled = "Y"
 installed = "Y"
+
+[settings]
+environment = "prod"
+date_format = "m/d/Y"

--- a/common/configuration_sample.ini
+++ b/common/configuration_sample.ini
@@ -55,4 +55,4 @@ installed = "Y"
 
 [settings]
 environment = "prod"
-date_format = "m/d/Y"
+date_format = "%m/%d/%Y"

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -953,7 +953,7 @@ class Resource extends DatabaseObject {
 							LEFT JOIN LicenseStatus LS ON LS.licenseStatusID = RLS.licenseStatusID";
 
 			$licSelectAdd = "GROUP_CONCAT(DISTINCT L.shortName ORDER BY L.shortName DESC SEPARATOR '; ') licenseNames,
-							GROUP_CONCAT(DISTINCT LS.shortName, ': ', DATE_FORMAT(RLS.licenseStatusChangeDate, '%m/%d/%Y') ORDER BY RLS.licenseStatusChangeDate DESC SEPARATOR '; ') licenseStatuses, ";
+							GROUP_CONCAT(DISTINCT LS.shortName, ': ', DATE_FORMAT(RLS.licenseStatusChangeDate, '" . return_date_format() . "') ORDER BY RLS.licenseStatusChangeDate DESC SEPARATOR '; ') licenseStatuses, ";
 
 		}
 


### PR DESCRIPTION
Currently, Coral's date format is hardcoded in common/common_directory.php
This patch allows to specify the date format in common/configuration.ini, with a fallback to the default date format if nothing is specified.

```
[settings]
date_format = "%m/%d/%Y"
```

