### PR TITLE
Issue 520: Allow to modify Date.format in the main common.js file

### DIFF
--- a/licensing/js/common.js
+++ b/licensing/js/common.js
@@ -30,14 +30,6 @@
 })(jQuery)
 
 
-
-//Required for date picker
-Date.firstDayOfWeek = 0;
-
-//suggested: mm/dd/yyyy OR dd-mm-yyyy
-Date.format = 'mm/dd/yyyy';
-
-
 $(function(){
 	$('.date-pick').datePicker({startDate:'01/01/1996'});
 

--- a/licensing/templates/header.php
+++ b/licensing/templates/header.php
@@ -79,6 +79,7 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/translate.js"></script>
 <script type="text/javascript" src="../js/plugins/datejs-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
+<script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
 </head>
 <body id="licensing">

--- a/management/js/common.js
+++ b/management/js/common.js
@@ -32,13 +32,6 @@
 
 
 
-//Required for date picker
-Date.firstDayOfWeek = 0;
-
-//suggested: mm/dd/yyyy OR dd-mm-yyyy
-Date.format = 'mm/dd/yyyy';
-
-
 $(function(){
 	loadDatePicker();
 

--- a/management/templates/header.php
+++ b/management/templates/header.php
@@ -78,6 +78,7 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.autocomplete.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.tooltip.js"></script>
+<script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
 </head>
 <body>

--- a/organizations/js/common.js
+++ b/organizations/js/common.js
@@ -30,11 +30,6 @@
 })(jQuery)
 
 
-//Required for date picker
-Date.firstDayOfWeek = 0;
-Date.format = 'mm/dd/yyyy';
-
-
 $(function(){
 	refreshContext();
 

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -72,6 +72,7 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/translate.js"></script>
 <script type="text/javascript" src="../js/plugins/datejs-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
+<script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
 </head>
 <body>

--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -33,9 +33,6 @@
 //Required for date picker
 Date.firstDayOfWeek = 0;
 
-//suggested: mm/dd/yyyy OR dd-mm-yyyy
-Date.format = 'mm/dd/yyyy';
-
 
 $(function(){
 	refreshContext();

--- a/resources/js/forms/costForm.js
+++ b/resources/js/forms/costForm.js
@@ -16,7 +16,10 @@
 */
 
 $(function(){
+
+
 	$('.date-pick').datePicker({startDate:'01/01/1996'});
+	$('.date-pick').attr('placeholder', Date.format);
 
 	//bind all of the inputs
 

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -70,6 +70,7 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/translate.js"></script>
 <script type="text/javascript" src="../js/plugins/datejs-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
+<script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Improvement/fix for #520 : Date.format (used by datepickers) is now configurable in a single file (`js/common.js` ) (instead of having to configure it in every module)