### PR TITLE
Issue 527: Fix resource search on note type and note text.

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -662,7 +662,7 @@ class Resource extends DatabaseObject {
 			$whereAdd[] = "(RNA.noteTypeID IS NULL) AND (RNA.noteText IS NOT NULL) AND (RNR.noteTypeID IS NULL) AND (RNR.noteText IS NOT NULL)";
 			$searchDisplay[] = _("Note Type: none");
 		}else if ($search['noteTypeID']) {
-			$whereAdd[] = "(RNA.noteTypeID = '" . $resource->db->escapeString($search['noteTypeID']) . "' AND RNA.tabName <> 'Product') OR (RNR.noteTypeID = '" . $resource->db->escapeString($search['noteTypeID']) . "' AND RNR.tabName = 'Product')";
+			$whereAdd[] = "((RNA.noteTypeID = '" . $resource->db->escapeString($search['noteTypeID']) . "' AND RNA.tabName <> 'Product') OR (RNR.noteTypeID = '" . $resource->db->escapeString($search['noteTypeID']) . "' AND RNR.tabName = 'Product'))";
 			$noteType = new NoteType(new NamedArguments(array('primaryKey' => $search['noteTypeID'])));
 			$searchDisplay[] = _("Note Type: ") . $noteType->shortName;
 		}


### PR DESCRIPTION
Fix for Issue #527 
Too many results were returned when searching on both note type and note text.

Test plan:
1) Apply the patch
2) Search resources using note type and note text
3) Check that the results are resources having a note of the searched type containing the searched text (and not a mix of both).