### PR TITLE
issue #445, licensing: use ANY_VALUE() around shortName column

### DIFF
--- a/licensing/admin/classes/domain/License.php
+++ b/licensing/admin/classes/domain/License.php
@@ -723,9 +723,9 @@ class License extends DatabaseObject {
 	//used for A-Z on search (index)
 	public function getAlphabeticalList(){
 		$alphArray = array();
-		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM ANY_VALUE(shortName)),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter_count
+		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter_count
 								FROM License L
-								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)
+								GROUP BY UPPER(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1))
 								ORDER BY 1;");
 
 		while ($row = mysqli_fetch_assoc($result)){

--- a/licensing/admin/classes/domain/License.php
+++ b/licensing/admin/classes/domain/License.php
@@ -723,7 +723,7 @@ class License extends DatabaseObject {
 	//used for A-Z on search (index)
 	public function getAlphabeticalList(){
 		$alphArray = array();
-		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter_count
+		$result = mysqli_query($this->db->getDatabase(), "SELECT DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM ANY_VALUE(shortName)),1,1)) letter, COUNT(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter_count
 								FROM License L
 								GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)
 								ORDER BY 1;");


### PR DESCRIPTION
see #445 

The underlying error from `PHP Warning:  mysqli_fetch_assoc() expects parameter
1 to be mysqli_result, boolean given in
…/licensing/admin/classes/domain/License.php on line 731, referer:
http://localhost:8080/coral/organizations/index.php`

is

`Expression #1 of SELECT list is not in GROUP BY clause and contains
nonaggregated column 'coral_licensing.L.shortName' which is not functionally
dependent on columns in GROUP BY clause; this is incompatible with
sql_mode=only_full_group_by`

Running the query directly in MySQL 5.7 will produce the error. Using the
ANY_VALUE() function suppresses the test for nondeterminism.

https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value