### PR TITLE
management: use ANY_VALUE() around shortName column

### DIFF
--- a/management/admin/classes/domain/License.php
+++ b/management/admin/classes/domain/License.php
@@ -797,7 +797,7 @@ class License extends DatabaseObject {
 		$alphArray = array();
 		$result = $this->db->query("
 			SELECT
-				DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter,
+				DISTINCT UPPER(SUBSTR(TRIM(LEADING 'The ' FROM ANY_VALUE(shortName)),1,1)) letter,
 				COUNT(SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)) letter_count
 			FROM License L
 			GROUP BY SUBSTR(TRIM(LEADING 'The ' FROM shortName),1,1)


### PR DESCRIPTION
see #445

Using the ANY_VALUE() function suppresses the test for nondeterminism.

https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value

```
PHP Fatal error:  Uncaught exception 'Exception' with message 'There was a
problem with the database: Expression #1 of SELECT list is not in GROUP BY
clause and contains nonaggregated column 'coral_management.L.shortName' which is
not functionally dependent on columns in GROUP BY clause; this is incompatible
with sql_mode=only_full_group_by' in …/management/admin/classes/common/DBService.php:55
Stack trace:
#0 …/management/admin/classes/common/DBService.php(82): DBService->checkForError()
#1 …/management/admin/classes/domain/License.php(804): DBService->query('\\n\\t\\t\\tSELECT\\n\\t\\t\\t\\t...')
#2 …/management/admin/classes/common/Object.php(55): License->getAlphabeticalList()
#3 …/management/index.php(229): Object->__get('getAlphabetical...')
#4 {main}
  thrown in …/management/admin/classes/common/DBService.php on line 55,
  referer: http://localhost:8080/coral/licensing/
```