### PR TITLE
Issue #543: set $expression->lastUpdateDate

### DIFF
--- a/licensing/ajax_processing.php
+++ b/licensing/ajax_processing.php
@@ -255,52 +255,51 @@ switch ($_GET['action']) {
 		break;
 
 
-	//add/update expression
+    // add/update expression
     case 'submitExpression':
 
-    	//if expressionID is sent then this is an update
-    	if ((isset($_POST['expressionID'])) && ($_POST['expressionID'] != '')){
-    		$expressionID = $_POST['expressionID'];
- 			$expression = new Expression(new NamedArguments(array('primaryKey' => $expressionID)));
-    	}else{
- 			$expression = new Expression();
- 			//default production use (terms tool indicator) to off if this is an add, otherwise we leave it alone
-			$expression->productionUseInd	= 0;
-			$expression->expressionID = '';
-		}
+      // if expressionID is sent then this is an update
+      if ((isset($_POST['expressionID'])) && ($_POST['expressionID'] != '')) {
+        $expressionID = $_POST['expressionID'];
+        $expression = new Expression(new NamedArguments(array('primaryKey' => $expressionID)));
+      }
+      else {
+        $expression = new Expression();
+        $expression->expressionID = '';
+        // set production use (terms tool indicator) to off when this is an add
+        $expression->productionUseInd = '0';
+      }
 
-		$expression->documentText		= $_POST['documentText'];
-		$expression->documentID 		= $_POST['documentID'];
-		$expression->expressionTypeID	= $_POST['expressionTypeID'];
-		$expression->productionUseInd	= '0';
-		$expression->simplifiedText		= '';
+      $expression->documentID = $_POST['documentID'];
+      $expression->expressionTypeID = $_POST['expressionTypeID'];
+      $expression->documentText = $_POST['documentText'];
+      $expression->simplifiedText = '';
+      $expression->lastUpdateDate = date('Y-m-d H:i:s');
 
-		try {
-			$expression->save();
+      try {
+        $expression->save();
 
-			if (!$expressionID){
-				$expressionID=$expression->primaryKey;
-			}
+        if (!$expressionID) {
+          $expressionID = $expression->primaryKey;
+        }
 
-			//first remove all qualifiers, then we'll add them back
-			$expression->removeQualifiers();
+        // first remove all qualifiers
+        $expression->removeQualifiers();
+        // then add them back
+        foreach (explode(',', $_POST['qualifiers']) as $id) {
+          if ($id) {
+            $expressionQualifierProfile = new ExpressionQualifierProfile();
+            $expressionQualifierProfile->expressionID = $expressionID;
+            $expressionQualifierProfile->qualifierID = $id;
+            $expressionQualifierProfile->save();
+          }
+        }
+      }
+      catch (Exception $e) {
+        echo $e->getMessage();
+      }
 
-			foreach (explode(',', $_POST['qualifiers']) as $id){
-				if ($id){
-					$expressionQualifierProfile = new ExpressionQualifierProfile();
-					$expressionQualifierProfile->expressionID = $expressionID;
-					$expressionQualifierProfile->qualifierID = $id;
-					$expressionQualifierProfile->save();
-				}
-			}
-
-
-
-		} catch (Exception $e) {
-			echo $e->getMessage();
-		}
-
-        break;
+      break;
 
 
     case 'deleteExpression':


### PR DESCRIPTION
The real changes besides white space include:

- set `$expression->productionUseInd` to a string in the `else` clause
- avoid rewriting `$expression->productionUseInd` immediately after the `else` clause (if it is an update and the value is already set, it would have been always overwritten)
- set `$expression->lastUpdateDate = date('Y-m-d H:i:s');` so that we don't get the cannot be null error

Issue #543 

# TEST PLAN

Environment (I believe the problem lies in the MySQL configuration):

- PHP Version 7.0.33-0ubuntu0.16.04.1
- MySQL Server version: 5.6.40-log Source distribution (AWS RDS)
  - `explicit_defaults_for_timestamp` set to `TRUE`
- Apache/2.4.18 (Ubuntu)

## Confirmation of Problem
Without the patch, when trying to add an Expression to a License in the Licensing module, the error *There was a problem with the database: Column 'lastUpdateDate' cannot be null* is shown and the Expression cannot be saved.

## Resolution
With the patch, the `lastUpdateDate` value is explicitly set so that the `DatabaseObject` code is not finding no value and trying to set the field to `NULL`. The Expression should save without any problems.