### PR TITLE
Issue 581: Specify datepickers date format in common/configuration.ini

### DIFF
--- a/common/common_directory.php
+++ b/common/common_directory.php
@@ -74,6 +74,17 @@ function return_date_format() {
     return $date_format;
 }
 
+function return_datepicker_date_format() {
+    $config = new Configuration();
+    $config_date_format = $config->settings->datepicker_date_format;
+    if (isset($config_date_format) && $config_date_format != '') {
+        $date_format = $config_date_format;
+    } else {
+        $date_format = "mm/dd/yyyy";
+    }
+    return $date_format;
+}
+
 function format_date($mysqlDate) {
 
 	//see http://php.net/manual/en/function.date.php for options

--- a/js/common.js
+++ b/js/common.js
@@ -34,7 +34,6 @@
 
 //Required for date picker
 Date.firstDayOfWeek = 0;
-Date.format = 'mm/dd/yyyy';
 
 
 // 1 visible, 0 hidden

--- a/licensing/templates/header.php
+++ b/licensing/templates/header.php
@@ -81,6 +81,9 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript">
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
+</script>
 </head>
 <body id="licensing">
 <noscript><font face='arial'><?php echo _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then ");?><a href=""><?php echo _("try again");?></a>. </font></noscript>

--- a/management/templates/header.php
+++ b/management/templates/header.php
@@ -80,6 +80,9 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/jquery.tooltip.js"></script>
 <script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript">
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
+</script>
 </head>
 <body>
 <noscript><font face='arial'><?php echo _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then ");?><a href=""><?php echo _("try again");?></a>. </font></noscript>

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -76,6 +76,7 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="js/common.js"></script>
 <script type="text/javascript">
 const CORAL_ILS_LINK=<?php echo $config->ils->ilsConnector ? 1 : 0; ?>
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
 </script>
 
 </head>

--- a/reports/templates/header.php
+++ b/reports/templates/header.php
@@ -67,6 +67,9 @@ $currentPage = $parts[count($parts) - 1];
 <script type="text/javascript" src="../js/plugins/jquery.tooltip.js"></script>
 <script type="text/javascript" src="js/plugins/jquery.floatThead.min.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript">
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
+</script>
 </head>
 <body>
 <?php echo "<noscript><font face=arial>" . _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then") . " <a href=''>" . _("try again") . "</a>. </font></noscript>";?>

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -72,6 +72,9 @@ $coralURL = $util->getCORALURL();
 <script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript">
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
+</script>
 </head>
 <body>
 <noscript><font face='arial'><?php echo _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then ");?><a href=""><?php echo _("try again");?></a>. </font></noscript>

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -67,6 +67,9 @@ $coralURL = $util->getCORALURL();
 ?>
 <script type="text/javascript" src="../js/plugins/translate.js"></script>
 <script type="text/javascript" src="js/common.js"></script>
+<script type="text/javascript">
+Date.format = '<?php echo return_datepicker_date_format(); ?>';
+</script>
 </head>
 <body>
 <noscript><font face='arial'><?php echo _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then ");?><a href=""><?php echo _("try again");?></a>. </font></noscript>


### PR DESCRIPTION
Background: Issue #581 : We shouldn't have to patch Coral to specify a date format for the datepickers (see PR #523) but rather be able to specify it in the main configuration file.

Datepickers date format can be specified in common/configuration.ini, as such:

```
[settings]
datepicker_date_format = "dd/mm/yyyy";
```

If datepicker_date_format is omitted, it will be defaulted to 'mm/dd/yyyy'