### PR TITLE
Issue 592: Import tool: detailed subjects

### DIFF
--- a/resources/admin/classes/common/DatabaseObject.php
+++ b/resources/admin/classes/common/DatabaseObject.php
@@ -243,7 +243,7 @@ class DatabaseObject extends DynamicObject {
                 $query = "INSERT INTO `$this->tableName` SET $set";
                 //echo $query;
                 $this->primaryKey = $this->db->processQuery($query);
-                if ($new) return $this->primaryKey;
+                return $this->primaryKey;
             }
         }
 	}

--- a/resources/admin/classes/domain/GeneralDetailSubjectLink.php
+++ b/resources/admin/classes/domain/GeneralDetailSubjectLink.php
@@ -26,12 +26,17 @@ class GeneralDetailSubjectLink extends DatabaseObject {
 
 
 	//returns the General Detail Subject Link ID when a general subject / detail subject is known.
+    // generalSubjectID can be null, if we want to find a GeneralDetailSubjectLink based on the detailedSubjectID only
+    // In this case, multiple GeneralDetailSubjectLinks can be returned, as an array.
 	public function getGeneralDetailID($generalSubjectID, $detailedSubjectID) {
 
 		$query = "SELECT * FROM GeneralDetailSubjectLink
-					WHERE generalSubjectID = " . $generalSubjectID .
-					" AND detailedSubjectID = " . $detailedSubjectID;
-
+					WHERE ";
+        if ($generalSubjectID) {
+            $query .= "generalSubjectID = " . $generalSubjectID . " AND detailedSubjectID = " . $detailedSubjectID;
+        } else {
+            $query .= "detailedSubjectID = " . $detailedSubjectID;
+        }
 		try {
 			$result = $this->db->processQuery($query, 'assoc');
 		} catch (Exception $e) {
@@ -40,7 +45,16 @@ class GeneralDetailSubjectLink extends DatabaseObject {
 
 
 		if ($result) {
-			return $result['generalDetailSubjectLinkID'];
+            if (isset($result['generalDetailSubjectLinkID'])) { $result = [$result]; }
+            $returnArray = array();
+            foreach ($result as $link) {
+                array_push($returnArray, $link['generalDetailSubjectLinkID']);
+            }
+            if (sizeof($returnArray) == 1) {
+                return $returnArray[0];
+            } else {
+                return $returnArray;
+            }
 		} else {
 			return -1;  // None is found
 		}

--- a/resources/ajax_forms/getImportConfigForm.php
+++ b/resources/ajax_forms/getImportConfigForm.php
@@ -131,11 +131,23 @@
 						if(count($configuration["subject"]) > 0) {
 							foreach($configuration["subject"] as $subject) {
 								echo "<div class='subject-record'><p><span class='ic-label'>" . _("Subject") . "</span><span><input class='ic-column' value='" . $subject['column'] . "' /></span></p>";
+								echo "<p><span class='ic-label'>" . _("Subject type") . "</span><span><select class='ic-type'>";
+                                echo '<option value="general"';
+                                if ($subject['type'] == "general") { echo ' selected="selected"'; }
+                                echo '>' . _("General Subject") . '</option>';
+                                echo '<option value="detailed"';
+                                if ($subject['type'] == "detailed") { echo ' selected="selected"'; }
+                                echo '>' . _("Detailed Subject") . '</option>';
+                                echo "</select></span></p>";
 								echo "<p><span class='ic-label'>" . _("If delimited, delimited by") . "</span><input class='ic-delimiter' value='" . $subject['delimiter'] . "' /></span></p></div>";
 							}
 						}
 						else {
 							echo "<div class='subject-record'><p><span class='ic-label'>" . _("Subject") . "</span><span><input class='ic-column' value='' /></span></p>";
+                            echo "<p><span class='ic-label'>" . _("Subject type") . "</span><span><select class='ic-type'>";
+                            echo '<option value="general">' . _("General Subject") . '</option>';
+                            echo '<option value="detailed">' . _("Detailed Subject") . '</option>';
+                            echo "</select></span></p>";
 							echo "<p><span class='ic-label'>" . _("If delimited, delimited by") . "</span><input class='ic-delimiter' value='' /></span></p></div>";
 						}
 					?>
@@ -314,7 +326,7 @@
    $('#add_subject').click(function (e) {
    		e.preventDefault();
    		$('#resource_subject').append(
-   			"<div class='subject-record'><p><span class='ic-label'><?php echo _('Subject');?></span><span><input class='ic-column' value='' /></span></p><p><span class='ic-label'><?php echo _('If delimited, delimited by');?></span><input class='ic-delimiter' value='' /></span></p></div>"
+   			"<div class='subject-record'><p><span class='ic-label'><?php echo _('Subject');?></span><span><input class='ic-column' value='' /></span></p><p><span class='ic-label'><?php echo _('Subject type'); ?></span><span><select class='ic-type'><option value='general'><?php echo _('General Subject'); ?></option><option value='detailed'><?php echo _('Detailed Subject'); ?></option></select></span></p><p><span class='ic-label'><?php echo _('If delimited, delimited by');?></span><input class='ic-delimiter' value='' /></span></p></div>"
    		);
    });
    $('#add_note').click(function (e) {

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -417,6 +417,7 @@ function submitImportConfigData() {
         $('div.subject-record').each(function() {
             var subjectObject = {};
             subjectObject.column = $(this).find('input.ic-column').val();
+            subjectObject.type = $(this).find('select.ic-type').find(':selected').val();
             subjectObject.delimiter = $(this).find('input.ic-delimiter').val();
             jsonData.subject.push(subjectObject);
         });


### PR DESCRIPTION
Background: issue #592 : Currently, only general subjects can be imported with the import tool. It would be nice to be able to import detailed subjects as well.

**This patch allows to define detailed subjets columns for the import tool.**

 - Because detailed subjects cannot be attached to a resource without a general subject, detailed subjects are not created: only existing detailed subjects are processed.

 - If the given detailed subject belongs to one or more general subjects, all
   the general subject/detailed subject couples are attached to the resource.

**Expected behavior/test plan:**

 - Import with an existing general subject: the resource is created with the general subject
 - Import with an existing detailed subject: the resource is created with the general/detailed subjects couples
 - Import with a non existing detailed subject: the resource is created, the detailed subject is not created
 - Import with a non existing general subject: the resource is created with the general subject