### PR TITLE
Dashboards: total cost details

### DIFF
--- a/resources/admin/classes/common/Dashboard.php
+++ b/resources/admin/classes/common/Dashboard.php
@@ -89,8 +89,6 @@ class Dashboard {
                     $sum_query = " SUM(if(RP.year = $i";
                     $sum_query .= " AND RP.costDetailsID = " . $costDetail['costDetailsID'];
 
-                    if ($orderTypeID) $sum_query .= " AND RP.orderTypeID = $orderTypeID";
-
                     $sum_query .= ", ROUND(COALESCE(RP.paymentAmount, 0) / 100, 2), 0))";
                     $sum_parts[] = $sum_query;
                 }

--- a/resources/ajax_htmldata/getDashboardYearlyCosts.php
+++ b/resources/ajax_htmldata/getDashboardYearlyCosts.php
@@ -36,6 +36,7 @@
             echo "<th>" . $costDetail['shortName'] . " / $i</th>";
         }
     }
+    echo ("<th>" . _("All cost details") . "</th>");
     echo "</tr></thead>";
     echo "<tbody>";
     $count = sizeof($results);
@@ -57,6 +58,7 @@
                     echo "<td>" . $result[$costDetail['shortName'] . " / $i"] . "</td>";
                 }
             }
+            echo ("<td>" . $result['costDetailsSum']. "</td>");
             echo "</tr>";
         } else {
             echo "<tr><td colspan='5'><b>";
@@ -68,6 +70,7 @@
                     echo "<td><b>" . $result[$costDetail['shortName'] . " / $i"] . "</b></td>";
                 }
             }
+            echo "<td><b>" . $result['costDetailsSum'] . "</b></td>";
             echo "</tr></tfoot>";
         }
         $currentCount++;


### PR DESCRIPTION
This development adds a total sum for all the cost details (today there are totals, but one for each cost detail only)

Before:
![before](https://user-images.githubusercontent.com/1679997/63697611-899ec000-c81d-11e9-9ba0-8fa55735a1ba.png)
After:
![after](https://user-images.githubusercontent.com/1679997/63697616-8c99b080-c81d-11e9-84f5-372448172618.png)

Test plan:
 - apply the patch
 - display a yearly costs dasboard with cost details
 - check that you have a new column called "All cost details" that sums the cost details of the line.



