### PR TITLE
Issue 578, OAuth: Get a brand new token if the server doesn't provide a refresh token

### DIFF
--- a/organizations/admin/classes/api_client/OAuth.php
+++ b/organizations/admin/classes/api_client/OAuth.php
@@ -35,9 +35,14 @@ class OAuth {
         } else {
             $existingAccessToken = unserialize($_SESSION['oauthToken']);
             if ($existingAccessToken->hasExpired()) {
-                $newAccessToken = $provider->getAccessToken('refresh_token', [
-                    'refresh_token' => $existingAccessToken->getRefreshToken()
-                ]);
+                $refresh_token = $existingAccessToken->getRefreshToken();
+                if ($refresh_token != null) {
+                    $newAccessToken = $provider->getAccessToken('refresh_token', [
+                        'refresh_token' => $refresh_token
+                    ]);
+                } else {
+                    $newAccessToken = $provider->getAccessToken('client_credentials');
+                }
                 $accessToken = $newAccessToken;
             } else {
                 $accessToken = $existingAccessToken;


### PR DESCRIPTION
Background: Issue #578 

Issuing a refresh token is optional at the discretion of the authorization server.

This patch allows Coral to ask for a brand new token if the OAuth server doesn't
provide a refresh token, instead of silently failing to authenticate.