### PR TITLE
Issue 604: Show all subjects in dashboards

### DIFF
--- a/resources/admin/classes/common/Dashboard.php
+++ b/resources/admin/classes/common/Dashboard.php
@@ -9,8 +9,8 @@ class Dashboard {
                         AT.shortName AS acquisitionType,
                         OT.shortName AS orderType,
                         CD.shortName AS costDetails,
-                        GS.shortName AS generalSubject,
-                        DS.shortName AS detailedSubject,
+                        GROUP_CONCAT(DISTINCT GS.shortName) AS generalSubjects,
+                        GROUP_CONCAT(DISTINCT DS.shortName) AS detailedSubjects,
                         RA.libraryNumber AS libraryNumber,
                         SUM(ROUND(COALESCE(RP.paymentAmount, 0) / 100, 2)) as paymentAmount
                         ";
@@ -55,8 +55,8 @@ class Dashboard {
                         RT.shortName AS resourceType,
                         AT.shortName AS acquisitionType,
                         CD.shortName AS costDetails,
-                        GS.shortName AS generalSubject,
-                        DS.shortName AS detailedSubject,
+                        GROUP_CONCAT(DISTINCT GS.shortName) AS generalSubjects,
+                        GROUP_CONCAT(DISTINCT DS.shortName) AS detailedSubjects,
                         RA.libraryNumber AS libraryNumber
                         ";
 

--- a/resources/ajax_htmldata/getDashboard.php
+++ b/resources/ajax_htmldata/getDashboard.php
@@ -20,7 +20,8 @@
     echo "<thead><tr>";
     echo "<th>" . _("Name") . "</th>";
     echo "<th>" . _("Resource Type") . "</th>";
-    echo "<th>" . _("Subject") . "</th>";
+    echo "<th>" . _("General Subjects") . "</th>";
+    echo "<th>" . _("Detailed Subjects") . "</th>";
     echo "<th>" . _("Acquisition Type") . "</th>";
     echo "<th>" . _("Library number") . "</th>";
     echo "<th>" . _("Payment amount") . "</th>";
@@ -33,16 +34,14 @@
             echo "<tr>";
             echo '<td><a href="resource.php?resourceID=' . $result['resourceID'] . '">' . $result['titleText'] . "</a></td>";
             echo "<td>" . $result['resourceType'] . "</td>";
-            $subject = $result['generalSubject'] && $result['detailedSubject'] ? 
-                $result['generalSubject'] . " / " . $result['detailedSubject'] : 
-                $result['generalSubject'] . $result['detailedSubject'];
-            echo "<td>" . $subject . "</td>";
+            echo "<td>" . $result['generalSubjects'] . "</td>";
+            echo "<td>" . $result['detailedSubjects'] . "</td>";
             echo "<td>" . $result['acquisitionType'] . "</td>";
             echo "<td>" . $result['libraryNumber'] . "</td>";
             echo "<td>" . $result['paymentAmount'] . "</td>";
             echo "</tr>";
         } else {
-            echo "<tr><td colspan='5'><b>";
+            echo "<tr><td colspan='6'><b>";
             if ($i == $count) { echo  _("Total"); } else { echo _("Sub-Total:") . " " . $result[$groupBy]; }
             echo "</b></td>";
             echo "<td><b>" . $result['paymentAmount']  . "</b></td>";

--- a/resources/ajax_htmldata/getDashboardYearlyCosts.php
+++ b/resources/ajax_htmldata/getDashboardYearlyCosts.php
@@ -27,7 +27,8 @@
     echo "<thead><tr>";
     echo "<th>" . _("Name") . "</th>";
     echo "<th>" . _("Resource Type") . "</th>";
-    echo "<th>" . _("Subject") . "</th>";
+    echo "<th>" . _("General Subjects") . "</th>";
+    echo "<th>" . _("Detailed Subjects") . "</th>";
     echo "<th>" . _("Acquisition Type") . "</th>";
     echo "<th>" . _("Library Number") . "</th>";
     for ($i = $startYear; $i <= $endYear; $i++) {
@@ -45,10 +46,8 @@
             echo "<tr>";
             echo '<td><a href="resource.php?resourceID=' . $result['resourceID'] . '">' . $result['titleText'] . "</a></td>";
             echo "<td>" . $result['resourceType'] . "</td>";
-            $subject = $result['generalSubject'] && $result['detailedSubject'] ? 
-                $result['generalSubject'] . " / " . $result['detailedSubject'] : 
-                $result['generalSubject'] . $result['detailedSubject'];
-            echo "<td>" . $subject . "</td>";
+            echo "<td>" . $result['generalSubjects'] . "</td>";
+            echo "<td>" . $result['detailedSubjects'] . "</td>";
             echo "<td>" . $result['acquisitionType'] . "</td>";
             echo "<td>" . $result['libraryNumber'] . "</td>";
             for ($i = $startYear; $i <= $endYear; $i++) {
@@ -59,7 +58,7 @@
             }
             echo "</tr>";
         } else {
-            echo "<tr><td colspan='5'><b>";
+            echo "<tr><td colspan='6'><b>";
             if ($currentCount == $count) { echo  _("Total"); } else { echo _("Sub-Total:") . " " . $result[$groupBy]; }
             echo "</b></td>";
             for ($i = $startYear; $i <= $endYear; $i++) {


### PR DESCRIPTION
Background: Issue #604 : not all subjects are displayed

> Currently, when several subjects are attached to a resource, only one of them (SQL-arbitrary) is displayed in the dashboards results.

This patch allows to display all subjects attached to a resource in the dashboards results.
Please note that this patch is not ideal: if an important number of subjects is attached to a resource, the results table will become less readable. An expand/collapse button might be a good idea, for example.