### PR TITLE
Sirsi sushi issues

### DIFF
--- a/usage/admin/classes/domain/SushiService.php
+++ b/usage/admin/classes/domain/SushiService.php
@@ -600,7 +600,8 @@ class SushiService extends DatabaseObject {
         }
 
         $string = file_get_contents($fName);
-        $clean_xml = str_ireplace(['s:','SOAP-ENV:','SOAP:','ns2:','ns3:'],'',$string);
+		// Gets rid of all namespace references
+        $clean_xml = $this->stripNamespaces($string);
         $xml = simplexml_load_string($clean_xml);
 
         $txtOut = "";
@@ -810,6 +811,24 @@ class SushiService extends DatabaseObject {
 		$this->saveLogAndExit($layoutCode, $txtFile, true);
 	}
 
+	private function stripNamespaces($string) {
+        $sxe = new SimpleXMLElement($string);
+        $doc = new DOMDocument();
+        $doc->loadXML($string);
+
+
+        foreach ($sxe->getNamespaces(true) as $name => $uri) {
+        	if(!empty($name)){
+                $finder = new DOMXPath($doc);
+                $nodes = $finder->query("//*[namespace::{$name} and not(../namespace::{$name})]");
+                foreach ($nodes as $n) {
+                    $ns_uri = $n->lookupNamespaceURI($name);
+                    $n->removeAttributeNS($ns_uri, $name);
+                }
+			}
+        }
+        return $doc->saveXML(null, LIBXML_NOEMPTYTAG);
+	}
 }
 
 

--- a/usage/admin/classes/domain/SushiService.php
+++ b/usage/admin/classes/domain/SushiService.php
@@ -600,7 +600,7 @@ class SushiService extends DatabaseObject {
         }
 
         $string = file_get_contents($fName);
-        $clean_xml = str_ireplace(['s:','SOAP-ENV:','SOAP:'],'',$string);
+        $clean_xml = str_ireplace(['s:','SOAP-ENV:','SOAP:','ns2:','ns3:'],'',$string);
         $xml = simplexml_load_string($clean_xml);
 
         $txtOut = "";


### PR DESCRIPTION
Removes name spaces from SUSHI responses. This the same fix but different code as PR #579.

This was previously a PR to coral:master, which was incorrect. I've correctly made this a PR to coral:development.