### PR TITLE
SirsiDynix: Additional Datepicker fixes

### DIFF
--- a/common/common_directory.php
+++ b/common/common_directory.php
@@ -98,6 +98,38 @@ function format_date($mysqlDate) {
 
 }
 
+function create_php_date_format_from_js_format($input_string) {
+
+  // Note the js format strings are specific to the datepicker plugin
+  $js_formats = array('/yyyy/','/yy/','/mmmm/','/mmm/','/mm/','/dd/');
+  // php format strings https://www.php.net/manual/en/function.date.php
+  $php_formats = array('Y','y','F','M','m','d');
+
+  return preg_replace($js_formats, $php_formats, $input_string);
+}
+
+function create_date_from_js_format($input) {
+  /*
+   * see https://andy-carter.com/blog/php-date-formats for overview of different php date formatters
+   * Coral utilizes strftime() and strtotime(), but strtotime expects dates to be formatted in US English
+   *
+   * Thus, while the above format_date() function works for mysql dates (which are stored as YYYY/MM/DD HH:MM:SS,
+   * it does not work for formatting form input dates, which are formatted via the datepiccker_date_format in common/configuration.ini
+   *
+   * E.g. a UK date of 26/11/2019 will return an error when using strtotime
+   *
+   * This function turns an input date into php Date object, which can then be utilized by strftime()
+   *
+   * To do so, it must convert datepicker format strings (e.g. 'dd' & 'mm') into php date format strings (e.g. 'd', 'm')
+   * using the create_php_date_format_from_js_format() function above
+   */
+
+  $datepicker_format = return_datepicker_date_format();
+  $php_format = create_php_date_format_from_js_format($datepicker_format);
+  return date_create_from_format($php_format, $input);
+
+}
+
 function debug($value) {
   echo '<pre>'.print_r($value, true).'</pre>';
 }

--- a/common/configuration_sample.ini
+++ b/common/configuration_sample.ini
@@ -56,3 +56,4 @@ installed = "Y"
 [settings]
 environment = "prod"
 date_format = "%m/%d/%Y"
+datepicker_date_format = "mm/dd/yyyy";

--- a/licensing/ajax_processing.php
+++ b/licensing/ajax_processing.php
@@ -59,7 +59,7 @@ switch ($_GET['action']) {
 
 		//first set effective Date for proper saving
 		if ((isset($_POST['effectiveDate'])) && ($_POST['effectiveDate'] != '')){
-			$document->effectiveDate = date("Y-m-d", strtotime($_POST['effectiveDate']));
+			$document->effectiveDate = create_date_from_js_format($_POST['effectiveDate'])->format('Y-m-d');
 		}else{
 			$document->effectiveDate= 'null';
 		}
@@ -212,7 +212,7 @@ switch ($_GET['action']) {
     case 'submitSignature':
     	//set date for proper saving
         if ((isset($_POST['signatureDate'])) && ($_POST['signatureDate'] != '')){
-			$signatureDate = date("Y-m-d", strtotime($_POST['signatureDate']));
+			$signatureDate = create_date_from_js_format($_POST['signatureDate'])->format('Y-m-d');
 		}else{
 			$signatureDate = "";
 		}
@@ -976,7 +976,7 @@ switch ($_GET['action']) {
 		}
 
     	if ((isset($_POST['sentDate'])) && ($_POST['sentDate'] <> "")){
-    		$attachment->sentDate = date("Y-m-d", strtotime($_POST['sentDate']));
+    		$attachment->sentDate = create_date_from_js_format($_POST['sentDate'])->format('Y-m-d');
     	}else{
     		$attachment->sentDate = "";
     	}

--- a/management/ajax_processing.php
+++ b/management/ajax_processing.php
@@ -56,13 +56,13 @@ switch ($_GET['action']) {
 
 		//first set effective Date for proper saving
 		if ((isset($_POST['effectiveDate'])) && ($_POST['effectiveDate'] != '')){
-			$document->effectiveDate = date("Y-m-d", strtotime($_POST['effectiveDate']));
+			$document->effectiveDate = create_date_from_js_format($_POST['effectiveDate'])->format('Y-m-d');
 		}else{
 			$document->effectiveDate= 'null';
 		}
 
 		if ((isset($_POST['revisionDate'])) && ($_POST['revisionDate'] != '')) {
-			$document->revisionDate = date("Y-m-d", strtotime($_POST['revisionDate']));
+			$document->revisionDate = create_date_from_js_format($_POST['revisionDate'])->format('Y-m-d');
 		}
 
 
@@ -217,7 +217,7 @@ switch ($_GET['action']) {
     case 'submitSignature':
     	//set date for proper saving
         if ((isset($_POST['signatureDate'])) && ($_POST['signatureDate'] != '')){
-			$signatureDate = date("Y-m-d", strtotime($_POST['signatureDate']));
+			$signatureDate = create_date_from_js_format($_POST['signatureDate'])->format('Y-m-d');
 		}else{
 			$signatureDate = "";
 		}
@@ -513,7 +513,7 @@ switch ($_GET['action']) {
 					$document->documentID = '';
 					$document->effectiveDate = date( 'Y-m-d H:i:s' );
 					if ((isset($_POST['revisionDate'])) && ($_POST['revisionDate'] != '')) {
-						$document->revisionDate = date("Y-m-d", strtotime($_POST['revisionDate']));
+						$document->revisionDate = create_date_from_js_format($_POST['revisionDate'])->format('Y-m-d');
 					}
 
 
@@ -1094,7 +1094,7 @@ switch ($_GET['action']) {
 		}
 
     	if ((isset($_POST['sentDate'])) && ($_POST['sentDate'] <> "")){
-    		$attachment->sentDate = date("Y-m-d", strtotime($_POST['sentDate']));
+    		$attachment->sentDate = create_date_from_js_format($_POST['sentDate'])->format('Y-m-d');
     	}else{
     		$attachment->sentDate = "";
     	}

--- a/organizations/ajax_processing.php
+++ b/organizations/ajax_processing.php
@@ -94,7 +94,7 @@ switch ($_GET['action']) {
                 // Create vendor in ILS
                 if ($organization->ilsID == null) {
                     $ilsID = $ilsClient->addVendor(array(
-                                                "name" => $organization->name, 
+                                                "name" => $organization->name,
                                                 "companyURL" => $organization->companyURL,
                                                 "noteText" => $organization->noteText,
                                                 "accountDetailText" => $organization->accountDetailText,
@@ -113,7 +113,7 @@ switch ($_GET['action']) {
                     $organization->accountDetailText = $ilsVendor['accountDetailText'];
                 }
                 $organization->save();
-            } 
+            }
 
 		} catch (Exception $e) {
 			echo $e->getMessage();
@@ -361,7 +361,7 @@ switch ($_GET['action']) {
 	case 'updateDowntime':
 		if (is_numeric($_POST['downtimeID'])) {
 			$downtime = new Downtime(new NamedArguments(array('primaryKey' => $_POST['downtimeID'])));
-			$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime($_POST['endDate']." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
+			$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']) : null;
 			$downtime->note = ($_POST['note']) ? $_POST['note']:null;
 			$downtime->save();
 		}
@@ -373,8 +373,8 @@ switch ($_GET['action']) {
 		$newDowntime->downtimeTypeID = $_POST['downtimeType'];
 		$newDowntime->issueID = $_POST['issueID'];
 
-		$newDowntime->startDate = date('Y-m-d H:i:s', strtotime($_POST['startDate']." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']));
-		$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime($_POST['endDate']." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
+		$newDowntime->startDate = date('Y-m-d H:i:s', create_date_from_js_format($_POST['statDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']);
+		$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']):null;
 
 		$newDowntime->dateCreated = date( 'Y-m-d H:i:s');
 		$newDowntime->entityTypeID = 1;
@@ -395,13 +395,13 @@ switch ($_GET['action']) {
 		}
 
 		if ($_POST['issueStartDate']){
-			$issueLog->issueStartDate = date("Y-m-d", strtotime($_POST['issueStartDate']));
+			$issueLog->issueStartDate = create_date_from_js_format($_POST['issueStartDate'])->format('Y-m-d');
 		}else{
 			$issueLog->issueStartDate = '';
 		}
 
     if ($_POST['issueEndDate']){
-			$issueLog->issueEndDate = date("Y-m-d", strtotime($_POST['issueEndDate']));
+			$issueLog->issueEndDate = create_date_from_js_format($_POST['issueEndDate'])->format('Y-m-d');
 		}else{
 			$issueLog->issueEndDate = '';
 		}

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -78,7 +78,6 @@ $coralURL = $util->getCORALURL();
 const CORAL_ILS_LINK=<?php echo $config->ils->ilsConnector ? 1 : 0; ?>;
 Date.format = '<?php echo return_datepicker_date_format(); ?>';
 </script>
-
 </head>
 <body>
 <noscript><font face='arial'><?php echo _("JavaScript must be enabled in order for you to use CORAL. However, it seems JavaScript is either disabled or not supported by your browser. To use CORAL, enable JavaScript by changing your browser options, then ");?><a href=""><?php echo _("try again");?></a>. </font></noscript>
@@ -93,12 +92,12 @@ Date.format = '<?php echo return_datepicker_date_format(); ?>';
 <div style="text-align:left;">
 
 <center>
-    
+
 <table class="titleTable" style="width:1024px;text-align:left;">
 
     <tr style='vertical-align:top;'>
         <td style='height:53px;' colspan='3'>
-                
+
             <div id="main-title">
                 <img src="images/title-icon-organizations.png" />
                 <span id="main-title-text"><?php echo _("Organizations"); ?></span>
@@ -131,18 +130,18 @@ Date.format = '<?php echo return_datepicker_date_format(); ?>';
                                 while (($file = readdir($dh)) !== false) {
                                     if (is_dir("$route/$file") && $file!="." && $file!=".."){
                                         $lang[]=$file;
-                                    } 
-                                } 
-                                closedir($dh); 
-                            } 
+                                    }
+                                }
+                                closedir($dh);
+                            }
                         }else {
-                            echo "<br>"._("Invalid translation route!"); 
+                            echo "<br>"._("Invalid translation route!");
                         }
                         // Get language of navigator
                         $defLang = $lang_name->getBrowserLanguage();
-                        
+
                         // Show an ordered list
-                        sort($lang); 
+                        sort($lang);
                         for($i=0; $i<count($lang); $i++){
                             if(isset($_COOKIE["lang"])){
                                 if($_COOKIE["lang"]==$lang[$i]){
@@ -159,7 +158,7 @@ Date.format = '<?php echo return_datepicker_date_format(); ?>';
                             }
                         }
                         ?>
-                        
+
                     </select>
                 </span>
             </div>
@@ -192,7 +191,7 @@ Date.format = '<?php echo return_datepicker_date_format(); ?>';
             <img src="images/menu/icon-admin.png" />
             <span><?php echo _("Admin"); ?></span>
         </div>
-    </a>   
+    </a>
 
 <?php }else if ($user->canEdit()){?>
 
@@ -232,7 +231,7 @@ Date.format = '<?php echo return_datepicker_date_format(); ?>';
             <img src="images/menu/icon-admin.png" />
             <span><?php echo _("Admin"); ?></span>
         </div>
-    </a>  
+    </a>
 
 <?php } ?>
 </td>

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -601,7 +601,8 @@ class Resource extends DatabaseObject {
 		}
 
 		if ($search['createDateStart']) {
-			$whereAdd[] = "R.createDate >= STR_TO_DATE('" . $resource->db->escapeString($search['createDateStart']) . "','%m/%d/%Y')";
+		  $startDate = create_date_from_js_format($search['createDateStart'])->format('Y-m-d');
+			$whereAdd[] = "R.createDate >= '". $resource->db->escapeString($startDate) ."'";
 			if (!$search['createDateEnd']) {
 				$searchDisplay[] = _("Created on or after: ") . $search['createDateStart'];
 			} else {
@@ -610,7 +611,8 @@ class Resource extends DatabaseObject {
 		}
 
 		if ($search['createDateEnd']) {
-			$whereAdd[] = "R.createDate <= STR_TO_DATE('" . $resource->db->escapeString($search['createDateEnd']) . "','%m/%d/%Y')";
+      $endDate = create_date_from_js_format($search['createDateEnd'])->format('Y-m-d');
+			$whereAdd[] = "R.createDate <= '" . $resource->db->escapeString($endDate) . "'";
 			if (!$search['createDateStart']) {
 				$searchDisplay[] = _("Created on or before: ") . $search['createDateEnd'];
 			}

--- a/resources/ajax_processing/insertDowntime.php
+++ b/resources/ajax_processing/insertDowntime.php
@@ -15,8 +15,8 @@ $newDowntime->creatorID = $user->loginID;
 $newDowntime->downtimeTypeID = $_POST['downtimeType'];
 $newDowntime->issueID = $_POST['issueID'];
 
-$newDowntime->startDate = date('Y-m-d H:i:s', strtotime($_POST['startDate']." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']));
-$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime($_POST['endDate']." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
+$newDowntime->startDate = date('Y-m-d H:i:s', create_date_from_js_format($_POST['startDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']);
+$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']) : null;
 
 $newDowntime->dateCreated = date( 'Y-m-d H:i:s');
 $newDowntime->note = ($_POST['note']) ? $_POST['note']:null;

--- a/resources/ajax_processing/submitAcquisitions.php
+++ b/resources/ajax_processing/submitAcquisitions.php
@@ -9,14 +9,14 @@
 
 		//first set current start Date for proper saving
 		if ((isset($_POST['currentStartDate'])) && ($_POST['currentStartDate'] != '')){
-			$resourceAcquisition->subscriptionStartDate = date("Y-m-d", strtotime($_POST['currentStartDate']));
+			$resourceAcquisition->subscriptionStartDate = create_date_from_js_format($_POST['currentStartDate'])->format('Y-m-d');
 		}else{
 			$resourceAcquisition->subscriptionStartDate = '';
 		}
 
 		//first set current end Date for proper saving
 		if ((isset($_POST['currentEndDate'])) && ($_POST['currentEndDate'] != '')){
-			$resourceAcquisition->subscriptionEndDate = date("Y-m-d", strtotime($_POST['currentEndDate']));
+			$resourceAcquisition->subscriptionEndDate = create_date_from_js_format($_POST['currentEndDate'])->format('Y-m-d');
 		}else{
 			$resourceAcquisition->subscriptionEndDate = '';
 		}

--- a/resources/ajax_processing/submitCost.php
+++ b/resources/ajax_processing/submitCost.php
@@ -27,8 +27,8 @@
 					$resourcePayment = new ResourcePayment();
 					$resourcePayment->resourceAcquisitionID    = $resourceAcquisitionID;
 					$resourcePayment->year          = $yearArray[$key];
-					$start = $subStartArray[$key] ? date("Y-m-d", strtotime($subStartArray[$key])) : null;
-					$end   = $subEndArray[$key]   ? date("Y-m-d", strtotime($subEndArray[$key]))   : null;
+					$start = $subStartArray[$key] ? create_date_from_js_format($subStartArray[$key])->format('Y-m-d') : null;
+					$end   = $subEndArray[$key]   ? create_date_from_js_format($subEndArray[$key])->format('Y-m-d') : null;
 					$resourcePayment->subscriptionStartDate = $start;
 					$resourcePayment->subscriptionEndDate   = $end;
 					$resourcePayment->fundID        = $fundIDArray[$key];

--- a/resources/ajax_processing/updateDowntime.php
+++ b/resources/ajax_processing/updateDowntime.php
@@ -2,7 +2,7 @@
 if (is_numeric($_POST['downtimeID'])) {
 	$downtime = new Downtime(new NamedArguments(array('primaryKey' => $_POST['downtimeID'])));
 
-	$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime($_POST['endDate']." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
+	$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']):null;
 
 	$downtime->note = ($_POST['note']) ? $_POST['note']:null;
 


### PR DESCRIPTION
This is an extension of #581 and #582 

Prior to this fix, dates within a form are formatted by the datepicker plugin. Thus, in the config file, if the format were `dd/mm/yyyy`, the date __January 2nd, 2019__ would be formatted _and submitted_ as the string `02/01/2019`.

But the php scripts that parse the `$_POST` variables are using [`strtotime()`](https://www.php.net/manual/en/function.strtotime.php), which "..expects to be given a string containing an English date format". Further digging into php docs showed that strtotime [only works with American date formatting](https://www.php.net/manual/en/datetime.formats.date.php) when using forward slashes, and has very specific formats for dashes.

Thus the above string of `02/01/2019` will always be parsed as __February 1st, 2019__ using `strtotime()`

Here, I've written the necessary functions to use [`date_create_from_format()`](https://www.php.net/manual/en/datetime.createfromformat.php), which, instead, lets you pass a specific format to the parser, so the parse knows exactly where days and months exist in the string.

## Testing
1. In `common/configuration.ini` Change the `datepicker_date_format` and `date_format` settings to something else (e.g. `dd-mm-yyyy` and `%d-%m-%Y`, respectively).
2. Create a new resource
3. Edit the resource's order (or add a new one) and change the subscription start-end dates.
4. The dates entered in the form should persist after the order information is submitted (prior to this fix, a data such as `20-12-2019` would have resulted in a 1969 date because strtotime cannot parse that string.