### PR TITLE
Issue 623: Search resources with no relationship

### DIFF
--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -555,9 +555,12 @@ class Resource extends DatabaseObject {
 
 
 		if ($search['parent'] != null) {
-			$parentadd = "(" . $search['parent'] . ".relationshipTypeID = 1";
-			$parentadd .= ")";
-			$whereAdd[] = $parentadd;
+            if ($search['parent'] == 'None') {
+                $parentadd = "(RRP.relationshipTypeID IS NULL AND RRC.relationshipTypeID IS NULL)";
+            } else {
+                $parentadd = "(" . $search['parent'] . ".relationshipTypeID = 1)";
+            }
+            $whereAdd[] = $parentadd;
 		}
 
 

--- a/resources/index.php
+++ b/resources/index.php
@@ -614,6 +614,7 @@ include 'templates/header.php';
 			<option value=''><?php echo _("All");?></option>
 			<option value='RRC'><?php echo _("Parent");?></option>
 			<option value='RRP'><?php echo _("Child");?></option>
+			<option value='None'><?php echo _("None");?></option>
 		</select>
 	</td>
 	</tr>


### PR DESCRIPTION
Background: see issue #623 

Currently, resources can be filtered with the following relationship criteria:

 - **All**: all resources are displayed (child, parent, or no relationship)
 - **Parent**: only parent resources are displayed
 - **Child**: only child resources are displayed

This patch adds the following criteria:

 - **None**: only resources that are neither parent nor child are displayed
   (ie: only resources with no relationship)

Test plan:
 - Perform a search on the resources index page, with 'None' in the Relationship
   dropdown list.
 - Check that only the resources with no relationship are displayed.