### PR TITLE
Add common classes to the reports module

### DIFF
--- a/reports/admin/classes/common/Base_Object.php
+++ b/reports/admin/classes/common/Base_Object.php
@@ -1,0 +1,89 @@
+<?php
+/*
+**************************************************************************************************************************
+** CORAL Licensing Module v. 1.0
+**
+** Copyright (c) 2010 University of Notre Dame
+**
+** This file is part of CORAL.
+**
+** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+**
+** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+**
+**************************************************************************************************************************
+*/
+
+
+class Base_Object {
+
+	public function __construct(NamedArguments $arguments = NULL) {
+		if (method_exists($this, 'init')) {
+			if (!is_a($arguments, 'NamedArguments')) {
+				$arguments = new NamedArguments(array());
+			}
+			$this->init($arguments);
+		}
+	}
+
+	// An optional initializer to use instead of |__construct()|.
+	protected function init(NamedArguments $arguments) {
+
+	}
+
+	public function __destruct() {
+		if (method_exists($this, 'dealloc')) {
+			$this->dealloc();
+		}
+	}
+
+	// An optional method called on deconstruction instead of |__deconstruct()|.
+	protected function dealloc() {
+
+	}
+
+	// Setters are functions called |$instance->setPropertyName($value)|.
+	public function __set($name, $value) {
+		$methodName = 'set' . ucfirst($name);
+		$this->$methodName($value);
+	}
+
+	// Getters are functions called |$instance->propertyName()|.
+	public function __get($name) {
+		return $this->$name();
+	}
+
+	// Default setter uses declared properties.
+	protected function setValueForKey($key, $value) {
+		if (property_exists($this, $key)) {
+			$this->$key = $value;
+		} else {
+			throw new Exception("Cannot set value for undefined key ($key).");
+		}
+	}
+
+	// Default getter uses declared properties.
+	protected function valueForKey($key) {
+		if (property_exists($this, $key)) {
+			return $this->$key;
+		} else {
+			throw new Exception(_("Cannot get value for undefined key (").$key.").");
+		}
+	}
+
+	// Call |valueForKey| and |setValueForKey| as default setter and getter.
+	public function __call($name, $arguments) {
+		if (preg_match('/^set[A-Z]/', $name)) {
+			$key = preg_replace('/^set/', '\1', $name);
+			$key = lcfirst($key);
+			$this->setValueForKey($key, $arguments[0]);
+		} else {
+			return $this->valueForKey($name);
+		}
+	}
+
+}
+
+?>

--- a/reports/admin/classes/common/Configuration.php
+++ b/reports/admin/classes/common/Configuration.php
@@ -1,0 +1,67 @@
+<?php
+/*
+**************************************************************************************************************************
+** CORAL Licensing Module v. 1.0
+**
+** Copyright (c) 2010 University of Notre Dame
+**
+** This file is part of CORAL.
+**
+** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+**
+** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+**
+**************************************************************************************************************************
+*/
+
+
+class Configuration extends DynamicObject {
+
+	public function init(NamedArguments $arguments) {
+		$global_config = parse_ini_file(BASE_DIR . "../common/configuration.ini", true);
+		$arguments->setDefaultValueForArgumentName("filename", BASE_DIR . "/admin/configuration.ini");
+		$module_config = parse_ini_file($arguments->filename, true);
+		$config = array_replace_recursive($global_config, $module_config);
+
+		// use other DBs for tests
+		if($config["settings"]["environment"] === "test") {
+			$this->switchAllDbsToTest($config);
+		}
+
+		// Save config array content as Configuration properties
+		foreach ($config as $section => $entries) {
+      $this->$section = (new Utility())->objectFromArray($entries);
+		}
+	}
+
+
+	private function switchAllDbsToTest(&$config) {
+		$config["database"]["name"] = "coral_licensing_test";
+		$config["database"]["username"] = "coral_test";
+		$config["database"]["password"] = "coral_test";
+
+		if(isset($config["database"]["usageDatabaseName"])) {
+			$config["database"]["usageDatabaseName"] = "coral_usage_test";
+		}
+
+		if(isset($config["settings"]["authDatabaseName"])) {
+			$config["settings"]["authDatabaseName"] = "coral_auth_test";
+		}
+
+		if(isset($config["settings"]["licensingDatabaseName"])) {
+			$config["settings"]["licensingDatabaseName"] = "coral_licensing_test";
+		}
+
+		if(isset($config["settings"]["organizationsDatabaseName"])) {
+			$config["settings"]["organizationsDatabaseName"] = "coral_organizations_test";
+		}
+
+		if(isset($config["settings"]["resourcesDatabaseName"])) {
+			$config["settings"]["resourcesDatabaseName"] = "coral_resources_test";
+		}
+	}
+}
+
+?>

--- a/reports/admin/classes/common/DynamicObject.php
+++ b/reports/admin/classes/common/DynamicObject.php
@@ -1,0 +1,46 @@
+<?php
+/*
+**************************************************************************************************************************
+** CORAL Licensing Module v. 1.0
+**
+** Copyright (c) 2010 University of Notre Dame
+**
+** This file is part of CORAL.
+**
+** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+**
+** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+**
+**************************************************************************************************************************
+*/
+
+
+class DynamicObject extends Base_Object {
+
+	protected $properties = array();
+
+	public function valueForKey($key) {
+		if (property_exists($this, $key)) {
+			return parent::valueForKey($key);
+		} else {
+			if (array_key_exists($key, $this->properties)) {
+				return $this->properties[$key];
+			} else {
+				return NULL;
+			}
+		}
+	}
+
+	public function setValueForKey($key, $value) {
+		if (property_exists($this, $key)) {
+			parent::setValueForKey($key, $value);
+		} else {
+			$this->properties[$key] = $value;
+		}
+	}
+
+}
+
+?>

--- a/reports/admin/classes/common/NamedArguments.php
+++ b/reports/admin/classes/common/NamedArguments.php
@@ -1,0 +1,54 @@
+<?php
+/*
+**************************************************************************************************************************
+** CORAL Licensing Module v. 1.0
+**
+** Copyright (c) 2010 University of Notre Dame
+**
+** This file is part of CORAL.
+**
+** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+**
+** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+**
+**************************************************************************************************************************
+*/
+
+
+class NamedArguments {
+
+	protected $arguments = array();
+
+	public function __construct($array) {
+		$this->arguments = $array;
+	}
+
+	public function __get($name) {
+		if (array_key_exists($name, $this->arguments)) {
+			return $this->arguments[$name];
+		}
+	}
+
+	public function __set($name, $value) {
+		$this->arguments[$name] = $value;
+	}
+
+	public function setDefaultValueForArgumentName($argumentName, $value) {
+		if (!array_key_exists($argumentName, $this->arguments)) {
+			$this->arguments[$argumentName] = $value;
+		}
+	}
+
+	public function toJsonString() {
+		return json_encode($this->arguments);
+	}
+
+	public function namedArgumentsFromJsonString($string) {
+		return new NamedAgruments(json_decode($string, true));
+	}
+
+}
+
+?>

--- a/reports/admin/classes/common/Utility.php
+++ b/reports/admin/classes/common/Utility.php
@@ -1,0 +1,112 @@
+<?php
+/*
+**************************************************************************************************************************
+** CORAL Organizations Module v. 1.0
+**
+** Copyright (c) 2010 University of Notre Dame
+**
+** This file is part of CORAL.
+**
+** CORAL is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+**
+** CORAL is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License along with CORAL.  If not, see <http://www.gnu.org/licenses/>.
+**
+**************************************************************************************************************************
+*/
+
+
+class Utility {
+
+	public function secondsFromDays($days) {
+		return $days * 24 * 60 * 60;
+	}
+
+	public function objectFromArray($array) {
+		$object = new DynamicObject;
+		foreach ($array as $key => $value) {
+			if (is_array($value)) {
+				$object->$key = Utility::objectFromArray($value);
+			} else {
+				$object->$key = $value;
+			}
+		}
+		return $object;
+	}
+
+	//returns file path up to /coral/
+	public function getCORALPath(){
+		$pagePath = $_SERVER["DOCUMENT_ROOT"];
+
+		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$parts = Explode('/', $currentFile);
+		for($i=0; $i<count($parts) - 2; $i++){
+			$pagePath .= $parts[$i] . '/';
+		}
+
+		return $pagePath;
+	}
+
+	//returns file path for this module, i.e. /coral/licensing/
+	public function getModulePath(){
+	  $replace_path = preg_quote(DIRECTORY_SEPARATOR."admin".DIRECTORY_SEPARATOR."classes".DIRECTORY_SEPARATOR."common");
+	  return preg_replace("@$replace_path$@", "", dirname(__FILE__));
+	}
+
+
+	//returns page URL up to /coral/
+	public function getCORALURL(){
+		$pageURL = 'http';
+		if (isset($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
+		$pageURL .= "://";
+		if ($_SERVER["SERVER_PORT"] != "80") {
+		  $pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"];
+		} else {
+		  $pageURL .= $_SERVER["SERVER_NAME"];
+		}
+
+		$currentFile = $_SERVER["PHP_SELF"];
+		$parts = Explode('/', $currentFile);
+		for($i=0; $i<count($parts) - 2; $i++){
+			$pageURL .= $parts[$i] . '/';
+		}
+
+		return $pageURL;
+	}
+
+	//returns page URL up to /reports/
+	public function getPageURL(){
+		return $this->getCORALURL() . "reports/";
+	}
+
+	public function getOrganizationURL(){
+		return $this->getCORALURL() . "organizations/orgDetail.php?organizationID=";
+	}
+
+	public function getResourceURL(){
+		return $this->getCORALURL() . "resources/resource.php?resourceID=";
+	}
+
+
+	public function getLoginCookie(){
+
+		if(array_key_exists('CORALLoginID', $_COOKIE)){
+			return $_COOKIE['CORALLoginID'];
+		}
+
+	}
+
+	public function getSessionCookie(){
+
+		if(array_key_exists('CORALSessionID', $_COOKIE)){
+			return $_COOKIE['CORALSessionID'];
+		}
+
+	}
+
+
+
+}
+
+?>


### PR DESCRIPTION
The reports module is currently broken:

PHP Fatal error:  Uncaught Error: Class 'Configuration' not found in /home/coral/www/common/common_directory.php:78

This patch adds the common classes also used by the other modules and fixes the problem.
This patch should be merged before release.
 