### PR TITLE
Issue 636: Add missing "All detail costs" column in yearly costs dashboards exports

### DIFF
--- a/resources/dashboard_yearly_costs_exports.php
+++ b/resources/dashboard_yearly_costs_exports.php
@@ -63,6 +63,7 @@
             $columnHeaders[] = $costDetail['shortName'] . " / $i";
         }
     }
+    $columnHeaders[] = _("All cost details");
     echo array_to_csv_row($columnHeaders);
 
     $count = sizeof($results);
@@ -89,7 +90,7 @@
                 $dashboardValues[] =  $result[$costDetail['shortName'] . " / $i"];
             }
         }
-
+        $dashboardValues[] = $result['costDetailsSum'];
         echo array_to_csv_row($dashboardValues);
         $currentCount++;
     }


### PR DESCRIPTION
Background: Issue #636  

Test plan:

 - Check that the "All detail costs" column is currently missing from yearly
   costs CSV exports (although displayed in the yearly costs page)

 - Apply the patch

 - Check that the column is now in the CSV exports and the values are correct.