### PR TITLE
Issue 638: Fix yearly costs dashboards sums for resources with multiple subjects

### DIFF
--- a/resources/admin/classes/common/Dashboard.php
+++ b/resources/admin/classes/common/Dashboard.php
@@ -115,10 +115,10 @@ class Dashboard {
             for ($i = $startYear; $i <= $endYear; $i++) {
                 foreach ($costDetailsArray as $costDetail) {
 
-                    $sum_query = " SUM(if(RP.year = $i";
+                    $sum_query = " SUM(DISTINCT(if(RP.year = $i";
                     $sum_query .= " AND RP.costDetailsID = " . $costDetail['costDetailsID'];
 
-                    $sum_query .= ", ROUND(COALESCE(RP.paymentAmount, 0) / 100, " . $number_decimals . "), 0))";
+                    $sum_query .= ", ROUND(COALESCE(RP.paymentAmount, 0) / 100, " . $number_decimals . "), 0)))";
                     $sum_parts[] = $sum_query;
                 }
             }


### PR DESCRIPTION
Background: issue #638 

Test plan:

 - Find a resource with several subjects attached.
 - Check that the 'All cost details' value is wrongly
   multiplied by the number of attached subjects.
 - Apply the patch.
 - Check that the 'All cost details' value is now correct.