### PR TITLE
Change the footer for 2020.02

### DIFF
--- a/templates/footer.php
+++ b/templates/footer.php
@@ -25,7 +25,7 @@
 </div>
 
 <div class="footer">
-  <?php echo _("Copyright");?> &copy; <?php echo date('Y'); ?>. <?php echo _("CORAL version");?> DEVELOPMENT<br/>
+  <?php echo _("Copyright");?> &copy; <?php echo date('Y'); ?>. <?php echo _("CORAL version");?> 2020.02<br/>
   <a href="http://coral-erm.org/"><?php echo _("CORAL Project Website");?></a> |
   <a href="https://github.com/coral-erm/coral/issues"><?php echo _("Report an Issue");?></a>
 </div>


### PR DESCRIPTION
Changing the footer in preparation for 2020.02 release. We need to change it back to DEVELOPMENT after the release is merged into the master branch.  