### PR TITLE
Blank note fields created by resources/import.php

### DIFF
--- a/resources/import.php
+++ b/resources/import.php
@@ -724,14 +724,16 @@
 							foreach($noteArray as $currentNote)
 							{
                                 if (isset($proceed)) {
-                                    $noteObj = new ResourceNote();
+			           if (!empty($currentNote)) {
+			            $noteObj = new ResourceNote();
                                     $noteObj->entityID = $resource->primaryKey;
                                     $noteObj->noteTypeID = $note['noteType'];
-                                    $noteObj->updateLoginID = '';
+                                    $noteObj->updateLoginID = $loginID;
                                     $noteObj->updateDate = date('Y-m-d H:i:s');
                                     $noteObj->noteText = $currentNote;
                                     $noteObj->tabName = 'Product';
-                                    $noteObj->save();
+				    $noteObj->save();
+				   }
                                 }
 								$noteInserted++;
 							}

--- a/resources/import.php
+++ b/resources/import.php
@@ -724,16 +724,16 @@
 							foreach($noteArray as $currentNote)
 							{
                                 if (isset($proceed)) {
-			           if (!empty($currentNote)) {
-			            $noteObj = new ResourceNote();
-                                    $noteObj->entityID = $resource->primaryKey;
-                                    $noteObj->noteTypeID = $note['noteType'];
-                                    $noteObj->updateLoginID = $loginID;
-                                    $noteObj->updateDate = date('Y-m-d H:i:s');
-                                    $noteObj->noteText = $currentNote;
-                                    $noteObj->tabName = 'Product';
-				    $noteObj->save();
-				   }
+									if (!empty($currentNote)) {
+										$noteObj = new ResourceNote();
+										$noteObj->entityID = $resource->primaryKey;
+										$noteObj->noteTypeID = $note['noteType'];
+										$noteObj->updateLoginID = $loginID;
+										$noteObj->updateDate = date('Y-m-d H:i:s');
+										$noteObj->noteText = $currentNote;
+										$noteObj->tabName = 'Product';
+										$noteObj->save();
+									}
                                 }
 								$noteInserted++;
 							}


### PR DESCRIPTION
Customer reports that when using the Resources module import utility, the system creates note fields for every column you specify in the import configuration, for each imported resource, even if there is no data in the relevant cell.

Moreover, the note appears with the date created, followed by the word "by" and then a blank empty space. It appears that the Created By field of the note is not given the username of the user running the import, as expected.

