### PR TITLE
Helpful links respects new tab/window confguration

### DIFF
--- a/licensing/ajax_htmldata.php
+++ b/licensing/ajax_htmldata.php
@@ -29,6 +29,7 @@
 include_once 'directory.php';
 include_once 'user.php';
 
+$target = getTarget();
 
 switch ($_GET['action']) {
 
@@ -1598,7 +1599,7 @@ switch ($_GET['action']) {
 
 				<?php
 				foreach ($resourceArray as $resource){
-					echo "<div class='rightPanelLink'><a href='" . $util->getResourceURL() . $resource['resourceID'] . "' target='_blank' class='helpfulLink'>" . $resource['resource'] . "</a></div>";
+					echo "<div class='rightPanelLink'><a href='" . $util->getResourceURL() . $resource['resourceID'] . "' $target class='helpfulLink'>" . $resource['resource'] . "</a></div>";
 				}
 
 				?>

--- a/organizations/orgDetail.php
+++ b/organizations/orgDetail.php
@@ -22,6 +22,8 @@ session_start();
 
 include_once 'directory.php';
 
+$target = getTarget();
+
 //if system number's passed in, it's a new request
 $organizationID = $_GET['organizationID'];
 $organization = new Organization(new NamedArguments(array('primaryKey' => $organizationID)));
@@ -98,7 +100,7 @@ if ($organization->name){
                     echo "<span style='color:grey; font-size:80%;'>"._("(archived)")." </span>";
                     $temp_style = "style='color:#888888'";
                 }
-                echo "<a href='" . $util->getResourceRecordURL() . $resource['resourceID'] . "' target='_BLANK' $temp_style>" .  $resource['titleText'] . "</a><br />";
+                echo "<a href='" . $util->getResourceRecordURL() . $resource['resourceID'] . "' $target $temp_style>" .  $resource['titleText'] . "</a><br />";
             }
             ?>
             </div>

--- a/resources/ajax_htmldata/getRightPanel.php
+++ b/resources/ajax_htmldata/getRightPanel.php
@@ -1,4 +1,5 @@
 <?php
+	$target = getTarget();
 	$resourceID = $_GET['resourceID'];
 	$resourceAcquisitionID = $_GET['resourceAcquisitionID'];
 	$resource = new Resource(new NamedArguments(array('primaryKey' => $resourceID)));
@@ -41,7 +42,7 @@
 		echo "<div style='background-color:white; width:219px; padding:7px;'>";
 		echo "<div class='rightPanelLink'><a href='summary.php?resourceID=" . $resource->resourceID . "&resourceAcquisitionID=" . $resourceAcquisitionID . "' target='_blank' class='helpfulLink'>"._("Print View")."</a></div>";
 		if (($resource->systemNumber) && ($config->settings->catalogURL != '')) {
-			echo "<div class='rightPanelLink'><a href='" . $config->settings->catalogURL . $resource->systemNumber . "' target='_blank'>"._("Catalog View")."</a></div>";
+			echo "<div class='rightPanelLink'><a href='" . $config->settings->catalogURL . $resource->systemNumber . "' $target '>"._("Catalog View")."</a></div>";
 		}
 		echo "</div>";
 
@@ -52,7 +53,7 @@
           echo "<div class='rightPanelHeader'>"._("Parent Record(s)")."</div>";
           foreach ($parentResourceArray as $parentResource){
             $parentResourceObj = new Resource(new NamedArguments(array('primaryKey' => $parentResource['relatedResourceID'])));
-              echo "<div class='rightPanelLink'><a href='resource.php?resourceID=" . $parentResourceObj->resourceID . "' target='_BLANK' class='helpfulLink'>" . $parentResourceObj->titleText . "</a></div>";
+              echo "<div class='rightPanelLink'><a href='resource.php?resourceID=" . $parentResourceObj->resourceID . "' $target class='helpfulLink'>" . $parentResourceObj->titleText . "</a></div>";
           }
         }
 
@@ -64,7 +65,7 @@
 						$i++;
 						$childResourceObj = new Resource(new NamedArguments(array('primaryKey' => $childResource['resourceID'])));
 						$initiallyHidden = $i > 20 ? 'helpfulLink__hidden' : '';
-						echo "<div class='rightPanelLink'><a href='resource.php?resourceID=" . $childResourceObj->resourceID . "' target='_BLANK' class='helpfulLink ".$initiallyHidden."'>" . $childResourceObj->titleText . "</a></div>";
+						echo "<div class='rightPanelLink'><a href='resource.php?resourceID=" . $childResourceObj->resourceID . "' $target class='helpfulLink ".$initiallyHidden."'>" . $childResourceObj->titleText . "</a></div>";
 					    if($i === 20) {
                             echo "<div class='rightPanelLink'><a href='#' class='helpfulLink' id='showAllChildResources' style='padding-left: 10px;'>+ show all resources (" .(count($childResourceArray) - 20)." more)</a></div>";
                         }
@@ -86,7 +87,7 @@
 
 				<?php
 				foreach ($orgArray as $organization){
-					echo "<div class='rightPanelLink'><a href='" . $util->getOrganizationURL() . $organization['organizationID'] . "' target='_blank' class='helpfulLink'>" . $organization['organization'] . "</a></div>";
+					echo "<div class='rightPanelLink'><a href='" . $util->getOrganizationURL() . $organization['organizationID'] . "' $target class='helpfulLink'>" . $organization['organization'] . "</a></div>";
 				}
 
 				?>
@@ -102,7 +103,7 @@
 
 				<?php
 				foreach ($licenseArray as $license){
-					echo "<div class='rightPanelLink'><a href='" . $util->getLicensingURL() . $license['licenseID'] . "' target='_blank' class='helpfulLink'>" . $license['license'] . "</a></div>";
+					echo "<div class='rightPanelLink'><a href='" . $util->getLicensingURL() . $license['licenseID'] . "' $target class='helpfulLink'>" . $license['license'] . "</a></div>";
 				}
 
 				?>
@@ -119,7 +120,7 @@
 				<div class='rightPanelHeader'><?php echo _("Usage Statistics Module");?></div>
 
 				<?php
-			echo "<form method='post' action='../reports/report.php' target='_blank'>";
+			echo "<form method='post' action='../reports/report.php' $target>";
 			echo "<input type='hidden' name='reportID' value='1'>";
 			echo "<input type='hidden' name='prm_3' value='".$resource->titleText."'>";
 			echo "<input type='submit' value='"._("Get Statistics")."'>";


### PR DESCRIPTION
The helpful links in the right-hand panel should also respect the configuration of whether new tabs/windows should be opened or not (set in common/configuration.ini). This PR adds this functionality.

The one exception is the "Print view" link, which still opens a new tab/window, since this is a common UX for print functionality. But this can be discussed!