### PR TITLE
More links respect the new window/tab configuration.

### DIFF
--- a/licensing/ajax_htmldata.php
+++ b/licensing/ajax_htmldata.php
@@ -29,6 +29,7 @@
 include_once 'directory.php';
 include_once 'user.php';
 
+$target = getTarget();
 
 switch ($_GET['action']) {
 
@@ -58,7 +59,7 @@ switch ($_GET['action']) {
 		if ($config->settings->organizationsModule == 'Y'){
 			$util = new Utility();
 
-			echo $license->getOrganizationName() . "  <a href='" . $util->getOrganizationURL() . $license->organizationID . "' target='_blank' style='text-decoration:none;'><i class='fa fa-pencil-square-o' style='margin-left:15px;'></i>"._("edit organization")."</a>";
+			echo $license->getOrganizationName() . "  <a href='" . $util->getOrganizationURL() . $license->organizationID . "' $target style='text-decoration:none;'><i class='fa fa-pencil-square-o' style='margin-left:15px;'></i>"._("edit organization")."</a>";
 
 			if ($license->consortiumID) {
 				echo "<br />" . $license->getConsortiumName();

--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -20,6 +20,7 @@
 
 include_once 'directory.php';
 include_once 'user.php';
+$target = getTarget();
 
 //shared html template for organization and resource issues
 function generateIssueHTML($issue,$associatedEntities=null) {
@@ -861,7 +862,7 @@ switch ($_GET['action']) {
 
 					foreach ($licenseArray as $license){
 						echo "<tr>\n";
-						echo "<td><a href='" . $licensingPath . $license['licenseID'] . "' target='_blank'>" . $license['licenseName'] . "</a></td>\n";
+						echo "<td><a href='" . $licensingPath . $license['licenseID'] . "' $target>" . $license['licenseName'] . "</a></td>\n";
 						echo "<td>" . $license['consortiumName'] . "</td>\n";
 						echo "<td>" . $license['status'] . "</td>\n";
 						echo "</tr>\n";

--- a/resources/ajax_htmldata/getAccountDetails.php
+++ b/resources/ajax_htmldata/getAccountDetails.php
@@ -1,4 +1,5 @@
 <?php
+	$target = getTarget();
 	$resourceID = $_GET['resourceID'];
 	$resource = new Resource(new NamedArguments(array('primaryKey' => $resourceID)));
 
@@ -56,7 +57,7 @@
 				<?php if (isset($externalLogin['organizationName'])) { ?>
 				<tr>
 				<td style='vertical-align:top; width:130px;'>Organization:</td>
-				<td><?php echo $externalLogin['organizationName'] . "&nbsp;&nbsp;<a href='" . $util->getCORALURL() . "organizations/orgDetail.php?showTab=accounts&organizationID=" . $externalLogin['organizationID'] . "' target='_blank'><img src='images/arrow-up-right.gif' alt='"._("Visit Account in Organizations Module")."' title='"._("Visit Account in Organizations Module")."' style='vertical-align:top;'></a>"; ?></td>
+				<td><?php echo $externalLogin['organizationName'] . "&nbsp;&nbsp;<a href='" . $util->getCORALURL() . "organizations/orgDetail.php?showTab=accounts&organizationID=" . $externalLogin['organizationID'] . "' $target><img src='images/arrow-up-right.gif' alt='"._("Visit Account in Organizations Module")."' title='"._("Visit Account in Organizations Module")."' style='vertical-align:top;'></a>"; ?></td>
 				</tr>
 				<?php
 				}

--- a/resources/ajax_htmldata/getAcquisitionsDetails.php
+++ b/resources/ajax_htmldata/getAcquisitionsDetails.php
@@ -23,7 +23,7 @@
 		$tableWidth = 646;
 		$formWidth = 564;
 	}
-
+	$target = getTarget();
 	$resourceID = $_GET['resourceID'];
 	$resource = new Resource(new NamedArguments(array('primaryKey' => $resourceID)));
 	$resourceAcquisitionID = $_GET['resourceAcquisitionID'];
@@ -235,7 +235,7 @@
 
 			if (count($licenseArray) > 0){
 				foreach ($licenseArray as $license){
-					echo $license['license'] . "&nbsp;&nbsp;<a href='" . $util->getLicensingURL() . $license['licenseID'] . "' target='_blank'><img src='images/arrow-up-right.gif' alt='"._("View License")."' title='"._("View License")."' style='vertical-align:top;'></a><br />";
+					echo $license['license'] . "&nbsp;&nbsp;<a href='" . $util->getLicensingURL() . $license['licenseID'] . "' $target><img src='images/arrow-up-right.gif' alt='"._("View License")."' title='"._("View License")."' style='vertical-align:top;'></a><br />";
 				}
 			}else{
 				echo "<i>"._("No associated licenses available.")."</i>";

--- a/resources/ajax_htmldata/getContactDetails.php
+++ b/resources/ajax_htmldata/getContactDetails.php
@@ -1,4 +1,5 @@
 <?php
+	$target = getTarget();
 	$resourceID = $_GET['resourceID'];
     $resourceAcquisitionID = isset($_GET['resourceAcquisitionID']) ? $_GET['resourceAcquisitionID'] : null;
 	if (isset($_GET['archiveInd'])) $archiveInd = $_GET['archiveInd']; else $archiveInd='';
@@ -83,7 +84,7 @@
 
 				<tr>
 				<td style='vertical-align:top;width:110px;'><?php echo _("Organization:");?></td>
-				<td><?php echo $contact['organizationName'] . "&nbsp;&nbsp;<a href='" . $util->getCORALURL() . "organizations/orgDetail.php?showTab=contacts&organizationID=" . $contact['organizationID'] . "' target='_blank'><img src='images/arrow-up-right.gif' alt='"._("Visit Contact in Organizations Module")."' title='"._("Visit Contact in Organizations Module")."' style='vertical-align:top;'></a>"; ?></td>
+				<td><?php echo $contact['organizationName'] . "&nbsp;&nbsp;<a href='" . $util->getCORALURL() . "organizations/orgDetail.php?showTab=contacts&organizationID=" . $contact['organizationID'] . "' $target><img src='images/arrow-up-right.gif' alt='"._("Visit Contact in Organizations Module")."' title='"._("Visit Contact in Organizations Module")."' style='vertical-align:top;'></a>"; ?></td>
 				</tr>
 
 				<?php

--- a/resources/ajax_htmldata/getProductDetails.php
+++ b/resources/ajax_htmldata/getProductDetails.php
@@ -9,6 +9,7 @@
 			$createUser = new User(new NamedArguments(array('primaryKey' => $resource->createLoginID)));
 			$updateUser = new User(new NamedArguments(array('primaryKey' => $resource->updateLoginID)));
 			$archiveUser = new User(new NamedArguments(array('primaryKey' => $resource->archiveLoginID)));
+			$target = getTarget();
 
       //get parents resources
       $sanitizedInstance = array();
@@ -191,7 +192,7 @@
         if (count($parentResourceArray) > 0) {
            foreach ($parentResourceArray as $parentResource){
               $parentResourceObj = new Resource(new NamedArguments(array('primaryKey' => $parentResource['relatedResourceID'])));
-            echo $parentResourceObj->titleText . "&nbsp;&nbsp;(Parent)&nbsp;&nbsp;<a href='resource.php?resourceID=" . $parentResourceObj->resourceID . "' target='_BLANK'><img src='images/arrow-up-right.gif' alt='"._("view resource")."' title='"._("View ") . $parentResourceObj->titleText . "' style='vertical-align:top;'></a><br />";
+            echo $parentResourceObj->titleText . "&nbsp;&nbsp;(Parent)&nbsp;&nbsp;<a href='resource.php?resourceID=" . $parentResourceObj->resourceID . "' $target><img src='images/arrow-up-right.gif' alt='"._("view resource")."' title='"._("View ") . $parentResourceObj->titleText . "' style='vertical-align:top;'></a><br />";
             }
          }
 
@@ -199,7 +200,7 @@
 					<?php
 					foreach ($childResourceArray as $childResource){
 						$childResourceObj = new Resource(new NamedArguments(array('primaryKey' => $childResource['resourceID'])));
-            echo $childResourceObj->titleText . "<a href='resource.php?resourceID=" . $childResourceObj->resourceID . "' target='_BLANK'><img src='images/arrow-up-right.gif' alt='"._("view resource")."' title='"._("View ") . $childResourceObj->titleText . "' style='vertical-align:top;'></a><br />";
+            echo $childResourceObj->titleText . "<a href='resource.php?resourceID=" . $childResourceObj->resourceID . "' $target><img src='images/arrow-up-right.gif' alt='"._("view resource")."' title='"._("View ") . $childResourceObj->titleText . "' style='vertical-align:top;'></a><br />";
 
 					}
 
@@ -253,7 +254,7 @@
 				foreach ($orgArray as $organization){
 					//if organizations is installed provide a link
 					if ($config->settings->organizationsModule == 'Y'){
-						echo "<span style='float:left; width:75px;'>" . $organization['organizationRole'] . ":</span><span style='width:270px;'>" . $organization['organization'] . "&nbsp;&nbsp;<a href='" . $util->getOrganizationURL() . $organization['organizationID'] . "' target='_blank'><img src='images/arrow-up-right.gif' alt='"._("View ") . $organization['organization'] . "' title='"._("View ") . $organization['organization'] . "' style='vertical-align:top;'></a></span><br />";
+						echo "<span style='float:left; width:75px;'>" . $organization['organizationRole'] . ":</span><span style='width:270px;'>" . $organization['organization'] . "&nbsp;&nbsp;<a href='" . $util->getOrganizationURL() . $organization['organizationID'] . "' $target><img src='images/arrow-up-right.gif' alt='"._("View ") . $organization['organization'] . "' title='"._("View ") . $organization['organization'] . "' style='vertical-align:top;'></a></span><br />";
 					}else{
 						echo "<span style='float:left; width:75px;'>" . $organization['organizationRole'] . ":</span><span style='width:270px;'>" . $organization['organization'] . "</span><br />";
 					}


### PR DESCRIPTION
More links in the resources, organizations and licensing modules now use the configuration (common/configuration.ini) whether to open new windows/tabs or not. This continues the work of PR #651  adding most links within the CORAL modules.

External urls, as well as documents, attachments etc. still open new windows. The one exception is the expression comparison in licensing, where the nature of the functionality suggest multiple windows, so I have left that unchanged. But am willing to discuss that further, if anyone disagrees! 