### PR TITLE
Add qualifiers to license Expressions tab for "view only" user

### DIFF
--- a/licensing/ajax_htmldata.php
+++ b/licensing/ajax_htmldata.php
@@ -1082,8 +1082,8 @@ switch ($_GET['action']) {
 				<tr>
 				<th style='width:80px;'><?php echo _("Type");?></th>
 				<th><?php echo _("Document Text");?></th>
+				<th><?php echo _("Qualifier");?></th>
 				<?php if ($user->canEdit()){ ?>
-					<th><?php echo _("Qualifier");?></th>
 					<th>&nbsp;</th>
 				<?php } ?>
 				</tr>
@@ -1135,20 +1135,18 @@ switch ($_GET['action']) {
 
 					<?php
 					echo "<td class='alt'>" . nl2br($expressionIns['documentText']) . "</td>";
+					echo "<td class='alt'>";
 
+					if (count($qualifierArray) > 0){
+						echo implode("<br />", $qualifierArray);
+					}
+
+					echo "</td>";
+					
 					if ($user->canEdit()){
-						echo "<td class='alt'>";
-
-						if (count($qualifierArray) > 0){
-							echo implode("<br />", $qualifierArray);
-						}else{
-							echo "&nbsp;";
-						}
-
-
-						echo "</td>";
 						echo "<td class='alt' style='text-align:center;'><a href='ajax_forms.php?action=getExpressionForm&licenseID=" . $licenseID . "&expressionID=" . $expressionIns['expressionID'] . "&height=420&width=345&modal=true' class='thickbox'><img id='Edit' src='images/edit.gif' title= '"._("Edit")."' /></a>&nbsp;&nbsp;<a href='javascript:deleteExpression(" . $expressionIns['expressionID'] . ");'><img id='Remove' class='removeIcon' src='images/cross.gif' title= '"._("Remove")."' /></a></td>";
 					}
+					
 					echo "</tr>";
 
 					if ($user->canEdit()){
@@ -1180,7 +1178,7 @@ switch ($_GET['action']) {
 					if ($user->canEdit()){
 						echo "<tr><td colspan='4'>&nbsp;</td></tr>";
 					}else{
-						echo "<tr><td colspan='2'>&nbsp;</td></tr>";
+						echo "<tr><td colspan='3'>&nbsp;</td></tr>";
 					}
 
 


### PR DESCRIPTION
A SirsiDynix customer reported that it is not possible to view the license expression qualifiers on the Expressions tab of the license record if the user has the "view only" privilege. This seems unintentional since the same user can view the qualifier on the Expression Comparison page. Moreover the tool tip for the user admin states "View only users can view all license information, including the license pdf."

This change adds the qualifier to the Expressions tab for users with the "view only" privilege. The option to edit or remove the expression does not appear.