### PR TITLE
Fix to downtime logging feature

### DIFF
--- a/organizations/ajax_processing.php
+++ b/organizations/ajax_processing.php
@@ -361,7 +361,7 @@ switch ($_GET['action']) {
 	case 'updateDowntime':
 		if (is_numeric($_POST['downtimeID'])) {
 			$downtime = new Downtime(new NamedArguments(array('primaryKey' => $_POST['downtimeID'])));
-			$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']) : null;
+			$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime(create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])) : null;
 			$downtime->note = ($_POST['note']) ? $_POST['note']:null;
 			$downtime->save();
 		}
@@ -373,8 +373,8 @@ switch ($_GET['action']) {
 		$newDowntime->downtimeTypeID = $_POST['downtimeType'];
 		$newDowntime->issueID = $_POST['issueID'];
 
-		$newDowntime->startDate = date('Y-m-d H:i:s', create_date_from_js_format($_POST['statDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']);
-		$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']):null;
+		$newDowntime->startDate = date('Y-m-d H:i:s', strtotime(create_date_from_js_format($_POST['startDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']));
+		$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime(create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
 
 		$newDowntime->dateCreated = date( 'Y-m-d H:i:s');
 		$newDowntime->entityTypeID = 1;

--- a/organizations/css/style.css
+++ b/organizations/css/style.css
@@ -2053,3 +2053,13 @@ table.titleTable {
 .editIcon  {
 	padding-left: 8px;
 }
+
+/*--- Add space before and after each downtime definition ---*/
+
+dt:first-child {
+    padding-top: .5em;
+}
+
+div.downtime {
+    padding-bottom: 1em;
+}

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -51,7 +51,6 @@ $target = getTarget();
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
 <script type="text/javascript" src="../js/plugins/jquery-1.8.0.js"></script>
 <script type="text/javascript" src="js/plugins/thickbox.js"></script>
-<script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.autocomplete.js"></script>
 <script type="text/javascript" src="../js/plugins/jquery.tooltip.js"></script>
 <script type="text/javascript" src="../js/plugins/Gettext.js"></script>

--- a/resources/admin/classes/domain/Organization.php
+++ b/resources/admin/classes/domain/Organization.php
@@ -172,15 +172,15 @@ class Organization extends DatabaseObject {
 		return $objects;
 	}
 
-	public function getExportableDowntimes($archivedOnly=false){
+	public function getExportableDowntimes($archivedOnly=false) {
 		$result = $this->getDownTimeResults($archivedOnly);
 
 		$objects = array();
 
 		//need to do this since it could be that there's only one request and this is how the dbservice returns result
-		if (isset($result['downtimeID'])){
+		if (isset($result['downtimeID'])) {
 			return array($result);
-		}else{
+		} else {
 			return $result;
 		}
 	}

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -430,9 +430,25 @@ class Resource extends DatabaseObject {
 
 
 
+	private function getDownTimeResults($archivedOnly=false) {
+		$query = "SELECT d.*
+			  FROM Downtime d
+			  WHERE d.entityID='{$this->primaryKey}'
+			  AND d.entityTypeID=2";
+
+		if ($archivedOnly) {
+			$query .= " AND d.endDate < CURDATE()";
+		} else {
+			$query .= " AND (d.endDate >= CURDATE() OR d.endDate IS NULL)";
+		}
+		$query .= "	ORDER BY d.dateCreated DESC";
+
+		return $this->db->processQuery($query, 'assoc');
+	}
 
 
-	public function getExportableDowntimes($archivedOnly=false){
+
+	public function getExportableDowntimes($archivedOnly=false) {
 		$result = $this->getDownTimeResults($archivedOnly);
 
 		$objects = array();
@@ -440,7 +456,7 @@ class Resource extends DatabaseObject {
 		//need to do this since it could be that there's only one request and this is how the dbservice returns result
 		if (isset($result['downtimeID'])) {
 			return array($result);
-		}else{
+		} else {
 			return $result;
 		}
 	}

--- a/resources/ajax_processing/insertDowntime.php
+++ b/resources/ajax_processing/insertDowntime.php
@@ -15,8 +15,8 @@ $newDowntime->creatorID = $user->loginID;
 $newDowntime->downtimeTypeID = $_POST['downtimeType'];
 $newDowntime->issueID = $_POST['issueID'];
 
-$newDowntime->startDate = date('Y-m-d H:i:s', create_date_from_js_format($_POST['startDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']);
-$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']) : null;
+$newDowntime->startDate = date('Y-m-d H:i:s', strtotime(create_date_from_js_format($_POST['startDate'])->format('Y-m-d')." ".$_POST['startTime']['hour'].":".$_POST['startTime']['minute'].$_POST['startTime']['meridian']));
+$newDowntime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s',  strtotime(create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])) : null;
 
 $newDowntime->dateCreated = date( 'Y-m-d H:i:s');
 $newDowntime->note = ($_POST['note']) ? $_POST['note']:null;

--- a/resources/ajax_processing/updateDowntime.php
+++ b/resources/ajax_processing/updateDowntime.php
@@ -2,7 +2,7 @@
 if (is_numeric($_POST['downtimeID'])) {
 	$downtime = new Downtime(new NamedArguments(array('primaryKey' => $_POST['downtimeID'])));
 
-	$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian']):null;
+	$downtime->endDate = ($_POST['endDate']) ?  date('Y-m-d H:i:s', strtotime(create_date_from_js_format($_POST['endDate'])->format('Y-m-d')." ".$_POST['endTime']['hour'].":".$_POST['endTime']['minute'].$_POST['endTime']['meridian'])):null;
 
 	$downtime->note = ($_POST['note']) ? $_POST['note']:null;
 

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -3282,7 +3282,6 @@ input#archiveInd {
     margin-bottom: 10px;
 }
 
-<<<<<<< HEAD
 /*--- Icons align in ProductsDetails ---*/
 .alignIcons{
 	display: flex;

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -3282,6 +3282,7 @@ input#archiveInd {
     margin-bottom: 10px;
 }
 
+<<<<<<< HEAD
 /*--- Icons align in ProductsDetails ---*/
 .alignIcons{
 	display: flex;
@@ -3315,4 +3316,14 @@ input#archiveInd {
 
 .addIconAlert {
 	vertical-align: 3px;
+}
+
+/*--- Add space before and after each downtime definition ---*/
+
+dt:first-child {
+    padding-top: .5em;
+}
+
+div.downtime {
+    padding-bottom: 1em;
 }


### PR DESCRIPTION
These changes address several issues with downtime logging:

- When entering downtime, all dates were incorrectly recorded as being in 1969. This was caused by a fix to allow configuration of date format used for the date picker tool. 
- Unable to enter downtime in the Organizations module (due to a typo on startDate).
- Unable to export downtime from the Resources module.

I've also made some very minor style changes to make it easier to see where one downtime definition ends and the next one starts in cases where there are several listed.