### PR TITLE
Update externalLoginSubmitForm.js

### DIFF
--- a/usage/js/forms/externalLoginSubmitForm.js
+++ b/usage/js/forms/externalLoginSubmitForm.js
@@ -51,11 +51,11 @@
 
 function validateExternalLogin() {
     if($("#username").val() == ''){
-        $("#span_errors").html('<br />' + _('Please enter a username to continue');
+        $("#span_errors").html('<br />' + _('Please enter a username to continue'));
         $("#username").focus();
         return false;
     }else if($("#password").val() == ''){
-        $("#span_errors").html('<br />' + _('For security, please enter a password');
+        $("#span_errors").html('<br />' + _('For security, please enter a password'));
         $("#password").focus();
         return false;
     }else{


### PR DESCRIPTION
In Usage module: The modal "getLoginForm" will not open. 

Usage module Home, click on a Platform entry, click on the tab Logins, click "add new login" There will be a waiting image, but the modal is not opening.

The problem was two unclosed parentheses in the javascript file.