### PR TITLE
string 'null' sent instead of null value caused data saving failure

### DIFF
--- a/licensing/ajax_processing.php
+++ b/licensing/ajax_processing.php
@@ -61,7 +61,7 @@ switch ($_GET['action']) {
 		if ((isset($_POST['effectiveDate'])) && ($_POST['effectiveDate'] != '')){
 			$document->effectiveDate = create_date_from_js_format($_POST['effectiveDate'])->format('Y-m-d');
 		}else{
-			$document->effectiveDate= 'null';
+			$document->effectiveDate = null;
 		}
 
 

--- a/management/ajax_processing.php
+++ b/management/ajax_processing.php
@@ -58,7 +58,7 @@ switch ($_GET['action']) {
 		if ((isset($_POST['effectiveDate'])) && ($_POST['effectiveDate'] != '')){
 			$document->effectiveDate = create_date_from_js_format($_POST['effectiveDate'])->format('Y-m-d');
 		}else{
-			$document->effectiveDate= 'null';
+			$document->effectiveDate = null;
 		}
 
 		if ((isset($_POST['revisionDate'])) && ($_POST['revisionDate'] != '')) {


### PR DESCRIPTION
On licensing upload form, if no effective date is entered, this induce a msql error
similar problem on management module