### PR TITLE
Use relative dates in report output

### DIFF
--- a/reports/admin/classes/report/UsageStatisticsYearlyUsageStatistics.php
+++ b/reports/admin/classes/report/UsageStatisticsYearlyUsageStatistics.php
@@ -18,7 +18,7 @@ class UsageStatisticsYearlyUsageStatistics extends Report {
 
     public function sql($isArchive) {
         $yearFields = '';
-        for ($y = 2015; $y >= 2008; $y--) {
+        for ($y = date("Y"); $y >= date("Y", strtotime("-84 months")); $y--) {
             $yearFields .= "max(IF(year=$y, totalCount, null)) '{$y}_ytd',";
         }
 


### PR DESCRIPTION
Yearly Usage Statistics report uses a hardcoded date range of 2008 to 2015. This change updates the date range to make it relative to the report run date, ending in the current year.