### PR TITLE
(issue #687 ) : Unable to Create "Categories" in Management Module

### DIFF
--- a/management/admin.php
+++ b/management/admin.php
@@ -135,12 +135,6 @@ if ($user->isAdmin()){
 -->
 
 
-<?php
-
-$config = new Configuration;
-
-//if the org module is not installed, display provider list for updates
-if ($config->settings->organizationsModule != 'Y'){ ?>
 
 
 	<br />
@@ -171,7 +165,6 @@ if ($config->settings->organizationsModule != 'Y'){ ?>
 	</td></tr>
 	</table>
 -->
-<?php } ?>
 
 <br />
 

--- a/management/ajax_forms.php
+++ b/management/ajax_forms.php
@@ -165,17 +165,8 @@ switch ($_GET['action']) {
 ?>
 							</span>
 
-<?php
-		$config = new Configuration;
-
-		//if the org module is not installed allow to add consortium from this screen
-		if (($config->settings->organizationsModule == 'N') || (!$config->settings->organizationsModule)){
-?>
 							<br />
 							<span id='span_newConsortium'><a href="javascript:newConsortium();"><?php echo _("add category");?></a></span>
-<?php
-		}
-?>
 
 						</td>
 					</tr>


### PR DESCRIPTION
(issue #687 ) : Removes the IF/THEN statements from management/ajax_forms.php and management/admin.php, always displaying an "Add Category" link in the Edit Document form on the former and always displaying the Categories table in the latter. In theory this is intended behavior in the Management Module given the existing documentation.