### PR TITLE
[747] Updates for jquery datepicker plugin and javascript includes cleanup

### DIFF
--- a/js/plugins/jquery.datePicker-patched-for-i18n.js
+++ b/js/plugins/jquery.datePicker-patched-for-i18n.js
@@ -1,22 +1,17 @@
 /**
- * Copyright (c) 2007 Kelvin Luck (http://www.kelvinluck.com/)
- * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) 
+ * Copyright (c) 2008 Kelvin Luck (http://www.kelvinluck.com/)
+ * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
- *
- * $Id: jquery.datePicker.js 3739 2007-10-25 13:55:30Z kelvin.luck $
- 
- * Amends by Mike Lehan http://m1ke.me
- * Fixes issues with running under jQuery >= 1.7
- ** Corrects "className" attribute to "class"
- ** Uses $.guid for numbering instead of deprecated $.event.guid
+ * .
+ * $Id$
  **/
 
 (function($){
-    
+
 	$.fn.extend({
 /**
  * Render a calendar table into any matched elements.
- * 
+ *
  * @param Object s (optional) Customize your calendars.
  * @option Number month The month to render (NOTE that months are zero based). Default is today's month.
  * @option Number year The year to render. Default is today's year.
@@ -48,7 +43,7 @@
  *	}
  * }
  * $('#calendar-me').renderCalendar({month:0, year:2007, renderCallback:testCallback});
- * 
+ *
  * @desc Renders a calendar displaying January 2007 into the element with an id of calendar-me. Every Thursday in the current month has a class of "thursday" applied to it, is clickable and shows an alert when clicked. Every Friday on the calendar has the number inside replaced with text.
  **/
 		renderCalendar  :   function(s)
@@ -57,19 +52,9 @@
 			{
 				return document.createElement(a);
 			};
-			
-			s = $.extend(
-				{
-					month			: null,
-					year			: null,
-					renderCallback	: null,
-					showHeader		: $.dpConst.SHOW_HEADER_SHORT,
-					dpController	: null,
-					hoverClass		: 'dp-hover'
-				}
-				, s
-			);
-			
+
+			s = $.extend({}, $.fn.datePicker.defaults, s);
+
 			if (s.showHeader != $.dpConst.SHOW_HEADER_NONE) {
 				var headRow = $(dc('tr'));
 				for (var i=Date.firstDayOfWeek; i<Date.firstDayOfWeek+7; i++) {
@@ -80,16 +65,16 @@
 					);
 				}
 			};
-			
+
 			var calendarTable = $(dc('table'))
 									.attr(
 										{
-											'cellspacing':2,
-											'class':'jCalendar'
+											'cellspacing':2
 										}
 									)
+									.addClass('jCalendar')
 									.append(
-										(s.showHeader != $.dpConst.SHOW_HEADER_NONE ? 
+										(s.showHeader != $.dpConst.SHOW_HEADER_NONE ?
 											$(dc('thead'))
 												.append(headRow)
 											:
@@ -97,56 +82,72 @@
 										)
 									);
 			var tbody = $(dc('tbody'));
-			
+
 			var today = (new Date()).zeroTime();
-			
+			today.setHours(12);
+
 			var month = s.month == undefined ? today.getMonth() : s.month;
 			var year = s.year || today.getFullYear();
-			
-			var currentDate = new Date(year, month, 1);
-			
-			
+
+			var currentDate = (new Date(year, month, 1, 12, 0, 0));
+
+
 			var firstDayOffset = Date.firstDayOfWeek - currentDate.getDay() + 1;
 			if (firstDayOffset > 1) firstDayOffset -= 7;
 			var weeksToDraw = Math.ceil(( (-1*firstDayOffset+1) + currentDate.getDaysInMonth() ) /7);
 			currentDate.addDays(firstDayOffset-1);
-			
-			var doHover = function()
+
+			var doHover = function(firstDayInBounds)
 			{
-				if (s.hoverClass) {
-					$(this).addClass(s.hoverClass);
+				return function()
+				{
+					if (s.hoverClass) {
+						var $this = $(this);
+						if (!s.selectWeek) {
+							$this.addClass(s.hoverClass);
+						} else if (firstDayInBounds && !$this.is('.disabled')) {
+							$this.parent().addClass('activeWeekHover');
+						}
+					}
 				}
 			};
 			var unHover = function()
 			{
 				if (s.hoverClass) {
-					$(this).removeClass(s.hoverClass);
+					var $this = $(this);
+					$this.removeClass(s.hoverClass);
+					$this.parent().removeClass('activeWeekHover');
 				}
 			};
-			
+
 			var w = 0;
 			while (w++<weeksToDraw) {
 				var r = jQuery(dc('tr'));
+				var firstDayInBounds = s.dpController ? currentDate > s.dpController.startDate : false;
 				for (var i=0; i<7; i++) {
 					var thisMonth = currentDate.getMonth() == month;
 					var d = $(dc('td'))
 								.text(currentDate.getDate() + '')
-								.attr('class', (thisMonth ? 'current-month ' : 'other-month ') +
+								.addClass((thisMonth ? 'current-month ' : 'other-month ') +
 													(currentDate.isWeekend() ? 'weekend ' : 'weekday ') +
 													(thisMonth && currentDate.getTime() == today.getTime() ? 'today ' : '')
 								)
-								.hover(doHover, unHover)
+								.data('datePickerDate', currentDate.asString())
+								.hover(doHover(firstDayInBounds), unHover)
 							;
+					r.append(d);
 					if (s.renderCallback) {
 						s.renderCallback(d, currentDate, month, year);
 					}
-					r.append(d);
-					currentDate.addDays(1);
+					// addDays(1) fails in some locales due to daylight savings. See issue 39.
+					//currentDate.addDays(1);
+					// set the time to midday to avoid any weird timezone issues??
+					currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate()+1, 12, 0, 0);
 				}
 				tbody.append(r);
 			}
 			calendarTable.append(tbody);
-			
+
 			return this.each(
 				function()
 				{
@@ -161,7 +162,7 @@
  *
  * dateSelected(event, date, $td, status)
  * Triggered when a date is selected. event is a reference to the event, date is the Date selected, $td is a jquery object wrapped around the TD that was clicked on and status is whether the date was selected (true) or deselected (false)
- * 
+ *
  * dpClosed(event, selected)
  * Triggered when the date picker is closed. event is a reference to the event and selected is an Array containing Date objects.
  *
@@ -174,21 +175,25 @@
  * @param Object s (optional) Customize your date pickers.
  * @option Number month The month to render when the date picker is opened (NOTE that months are zero based). Default is today's month.
  * @option Number year The year to render when the date picker is opened. Default is today's year.
- * @option String startDate The first date date can be selected.
- * @option String endDate The last date that can be selected.
+ * @option String|Date startDate The first date date can be selected.
+ * @option String|Date endDate The last date that can be selected.
  * @option Boolean inline Whether to create the datePicker as inline (e.g. always on the page) or as a model popup. Default is false (== modal popup)
  * @option Boolean createButton Whether to create a .dp-choose-date anchor directly after the matched element which when clicked will trigger the showing of the date picker. Default is true.
  * @option Boolean showYearNavigation Whether to display buttons which allow the user to navigate through the months a year at a time. Default is true.
  * @option Boolean closeOnSelect Whether to close the date picker when a date is selected. Default is true.
  * @option Boolean displayClose Whether to create a "Close" button within the date picker popup. Default is false.
  * @option Boolean selectMultiple Whether a user should be able to select multiple dates with this date picker. Default is false.
+ * @option Number numSelectable The maximum number of dates that can be selected where selectMultiple is true. Default is a very high number.
  * @option Boolean clickInput If the matched element is an input type="text" and this option is true then clicking on the input will cause the date picker to appear.
+ * @option Boolean rememberViewedMonth Whether the datePicker should remember the last viewed month and open on it. If false then the date picker will always open with the month for the first selected date visible.
+ * @option Boolean selectWeek Whether to select a complete week at a time...
  * @option Number verticalPosition The vertical alignment of the popped up date picker to the matched element. One of $.dpConst.POS_TOP and $.dpConst.POS_BOTTOM. Default is $.dpConst.POS_TOP.
  * @option Number horizontalPosition The horizontal alignment of the popped up date picker to the matched element. One of $.dpConst.POS_LEFT and $.dpConst.POS_RIGHT.
  * @option Number verticalOffset The number of pixels offset from the defined verticalPosition of this date picker that it should pop up in. Default in 0.
  * @option Number horizontalOffset The number of pixels offset from the defined horizontalPosition of this date picker that it should pop up in. Default in 0.
- * @option (Function|Array) renderCallback A reference to a function (or an array of seperate functions) that is called as each cell is rendered and which can add classes and event listeners to the created nodes. Each callback function will receive four arguments; a jquery object wrapping the created TD, a Date object containing the date this TD represents, a number giving the currently rendered month and a number giving the currently rendered year. Default is no callback.
+ * @option (Function|Array) renderCallback A reference to a function (or an array of separate functions) that is called as each cell is rendered and which can add classes and event listeners to the created nodes. Each callback function will receive four arguments; a jquery object wrapping the created TD, a Date object containing the date this TD represents, a number giving the currently rendered month and a number giving the currently rendered year. Default is no callback.
  * @option String hoverClass The class to attach to each cell when you hover over it (to allow you to use hover effects in IE6 which doesn't support the :hover pseudo-class on elements other than links). Default is dp-hover. Pass false if you don't want a hover class.
+ * @option String autoFocusNextInput Whether focus should be passed onto the next input in the form (true) or remain on this input (false) when a date is selected and the calendar closes
  * @type jQuery
  * @name datePicker
  * @cat plugins/datePicker
@@ -201,56 +206,35 @@
  * @desc See the projects homepage for many more complex examples...
  **/
 		datePicker : function(s)
-		{			
+		{
 			if (!$.event._dpCache) $.event._dpCache = [];
-			
+
 			// initialise the date picker controller with the relevant settings...
-			s = $.extend(
-				{
-					month				: undefined,
-					year				: undefined,
-					startDate			: undefined,
-					endDate				: undefined,
-					inline				: false,
-					renderCallback		: [],
-					createButton		: true,
-					showYearNavigation	: true,
-					closeOnSelect		: true,
-					displayClose		: false,
-					selectMultiple		: false,
-					clickInput			: false,
-					verticalPosition	: $.dpConst.POS_TOP,
-					horizontalPosition	: $.dpConst.POS_LEFT,
-					verticalOffset		: 0,
-					horizontalOffset	: 0,
-					hoverClass			: 'dp-hover'
-				}
-				, s
-			);
-			
+			s = $.extend({}, $.fn.datePicker.defaults, s);
+
 			return this.each(
 				function()
 				{
 					var $this = $(this);
 					var alreadyExists = true;
-					
+
 					if (!this._dpId) {
 						this._dpId = $.guid++;
 						$.event._dpCache[this._dpId] = new DatePicker(this);
 						alreadyExists = false;
 					}
-					
+
 					if (s.inline) {
 						s.createButton = false;
 						s.displayClose = false;
 						s.closeOnSelect = false;
 						$this.empty();
 					}
-					
+
 					var controller = $.event._dpCache[this._dpId];
-					
+
 					controller.init(s);
-					
+
 					if (!alreadyExists && s.createButton) {
 						// create it!
 						controller.button = $('<a href="#" class="dp-choose-date" title="' + $.dpText.TEXT_CHOOSE_DATE + '">' + $.dpText.TEXT_CHOOSE_DATE + '</a>')
@@ -265,7 +249,7 @@
 								);
 						$this.after(controller.button);
 					}
-					
+
 					if (!alreadyExists && $this.is(':text')) {
 						$this
 							.bind(
@@ -278,9 +262,13 @@
 								'change',
 								function()
 								{
-									var d = Date.fromString(this.value);
-									if (d) {
-										controller.setSelected(d, true, true);
+									if (this.value == '') {
+										controller.clearSelected();
+									} else {
+										var d = Date.fromString(this.value);
+										if (d) {
+											controller.setSelected(d, true, true);
+										}
 									}
 								}
 							);
@@ -289,6 +277,8 @@
 								'click',
 								function()
 								{
+									// The change event doesn't happen until the input loses focus so we need to manually trigger it...
+									$this.trigger('change');
 									$this.dpDisplay();
 								}
 							);
@@ -298,9 +288,9 @@
 							controller.setSelected(d, true, true);
 						}
 					}
-					
+
 					$this.addClass('dp-applied');
-					
+
 				}
 			)
 		},
@@ -324,7 +314,7 @@
 /**
  * Updates the first selectable date for any date pickers on any matched elements.
  *
- * @param String d A string representing the first selectable date (formatted according to Date.format).
+ * @param String|Date d A Date object or string representing the first selectable date (formatted according to Date.format).
  * @type jQuery
  * @name dpSetStartDate
  * @cat plugins/datePicker
@@ -341,7 +331,7 @@
 /**
  * Updates the last selectable date for any date pickers on any matched elements.
  *
- * @param String d A string representing the last selectable date (formatted according to Date.format).
+ * @param String|Date d A Date object or string representing the last selectable date (formatted according to Date.format).
  * @type jQuery
  * @name dpSetEndDate
  * @cat plugins/datePicker
@@ -378,9 +368,10 @@
 /**
  * Selects or deselects a date on any matched element's date pickers. Deselcting is only useful on date pickers where selectMultiple==true. Selecting will only work if the passed date is within the startDate and endDate boundries for a given date picker.
  *
- * @param String d A string representing the date you want to select (formatted according to Date.format).
+ * @param String|Date d A Date object or string representing the date you want to select (formatted according to Date.format).
  * @param Boolean v Whether you want to select (true) or deselect (false) this date. Optional - default = true.
  * @param Boolean m Whether you want the date picker to open up on the month of this date when it is next opened. Optional - default = true.
+ * @param Boolean e Whether you want the date picker to dispatch events related to this change of selection. Optional - default = true.
  * @type jQuery
  * @name dpSetSelected
  * @cat plugins/datePicker
@@ -390,11 +381,12 @@
  * $('.date-picker').dpSetSelected('01/01/2010');
  * @desc Creates a date picker associated with all elements with a class of "date-picker" then sets the selected date on these date pickers to the first Janurary 2010. When the date picker is next opened it will display Janurary 2010.
  **/
-		dpSetSelected : function(d, v, m)
+		dpSetSelected : function(d, v, m, e)
 		{
 			if (v == undefined) v=true;
 			if (m == undefined) m=true;
-			return _w.call(this, 'setSelected', Date.fromString(d), v, m);
+			if (e == undefined) e=true;
+			return _w.call(this, 'setSelected', Date.fromString(d), v, m, e);
 		},
 /**
  * Sets the month that will be displayed when the date picker is next opened. If the passed month is before startDate then the month containing startDate will be displayed instead. If the passed month is after endDate then the month containing the endDate will be displayed instead.
@@ -412,7 +404,7 @@
  **/
 		dpSetDisplayedMonth : function(m, y)
 		{
-			return _w.call(this, 'setDisplayedMonth', Number(m), Number(y));
+			return _w.call(this, 'setDisplayedMonth', Number(m), Number(y), true);
 		},
 /**
  * Displays the date picker associated with the matched elements. Since only one date picker can be displayed at once then the date picker associated with the last matched element will be the one that is displayed.
@@ -510,11 +502,23 @@
  *				$(this).dpClose();
  *			}
  *		);
- * @desc Creates a date picker and makes it appear when the relevant element is focused and disappear when it is blurred.
  **/
 		dpClose : function()
 		{
 			return _w.call(this, '_closeCalendar', false, this[0]);
+		},
+/**
+ * Rerenders the date picker's current month (for use with inline calendars and renderCallbacks).
+ *
+ * @type jQuery
+ * @name dpRerenderCalendar
+ * @cat plugins/datePicker
+ * @author Kelvin Luck (http://www.kelvinluck.com/)
+ *
+ **/
+		dpRerenderCalendar : function()
+		{
+			return _w.call(this, '_rerenderCalendar');
 		},
 		// private function called on unload to clean up any expandos etc and prevent memory links...
 		_dpDestroy : function()
@@ -522,26 +526,26 @@
 			// TODO - implement this?
 		}
 	});
-	
+
 	// private internal function to cut down on the amount of code needed where we forward
 	// dp* methods on the jQuery object on to the relevant DatePicker controllers...
-	var _w = function(f, a1, a2, a3)
+	var _w = function(f, a1, a2, a3, a4)
 	{
 		return this.each(
 			function()
 			{
 				var c = _getController(this);
 				if (c) {
-					c[f](a1, a2, a3);
+					c[f](a1, a2, a3, a4);
 				}
 			}
 		);
 	};
-	
+
 	function DatePicker(ele)
 	{
 		this.ele = ele;
-		
+
 		// initial values...
 		this.displayedMonth		=	null;
 		this.displayedYear		=	null;
@@ -550,7 +554,10 @@
 		this.showYearNavigation	=	null;
 		this.closeOnSelect		=	null;
 		this.displayClose		=	null;
+		this.rememberViewedMonth=	null;
 		this.selectMultiple		=	null;
+		this.numSelectable		=	null;
+		this.numSelected		=	null;
 		this.verticalPosition	=	null;
 		this.horizontalPosition	=	null;
 		this.verticalOffset		=	null;
@@ -560,10 +567,11 @@
 		this.selectedDates		=	{};
 		this.inline				=	null;
 		this.context			=	'#dp-popup';
+		this.settings			=	{};
 	};
 	$.extend(
 		DatePicker.prototype,
-		{	
+		{
 			init : function(s)
 			{
 				this.setStartDate(s.startDate);
@@ -573,12 +581,16 @@
 				this.showYearNavigation = s.showYearNavigation;
 				this.closeOnSelect = s.closeOnSelect;
 				this.displayClose = s.displayClose;
+				this.rememberViewedMonth =	s.rememberViewedMonth;
 				this.selectMultiple = s.selectMultiple;
+				this.numSelectable = s.selectMultiple ? s.numSelectable : 1;
+				this.numSelected = 0;
 				this.verticalPosition = s.verticalPosition;
 				this.horizontalPosition = s.horizontalPosition;
 				this.hoverClass = s.hoverClass;
 				this.setOffset(s.verticalOffset, s.horizontalOffset);
 				this.inline = s.inline;
+				this.settings = s;
 				if (this.inline) {
 					this.context = this.ele;
 					this.display();
@@ -587,7 +599,11 @@
 			setStartDate : function(d)
 			{
 				if (d) {
-					this.startDate = Date.fromString(d);
+					if (d instanceof Date) {
+						this.startDate = d;
+					} else {
+						this.startDate = Date.fromString(d);
+					}
 				}
 				if (!this.startDate) {
 					this.startDate = (new Date()).zeroTime();
@@ -597,7 +613,11 @@
 			setEndDate : function(d)
 			{
 				if (d) {
-					this.endDate = Date.fromString(d);
+					if (d instanceof Date) {
+						this.endDate = d;
+					} else {
+						this.endDate = Date.fromString(d);
+					}
 				}
 				if (!this.endDate) {
 					this.endDate = (new Date('12/31/2999')); // using the JS Date.parse function which expects mm/dd/yyyy
@@ -630,7 +650,7 @@
 					$e.attr('disabled', s ? 'disabled' : '');
 				}
 			},
-			setDisplayedMonth : function(m, y)
+			setDisplayedMonth : function(m, y, rerender)
 			{
 				if (this.startDate == undefined || this.endDate == undefined) {
 					return;
@@ -639,7 +659,7 @@
 				s.setDate(1);
 				var e = new Date(this.endDate.getTime());
 				e.setDate(1);
-				
+
 				var t;
 				if ((!m && !y) || (isNaN(m) && isNaN(y))) {
 					// no month or year passed - default to current month
@@ -655,61 +675,121 @@
 					// year and month passed in - that's the date we want!
 					t = new Date(y, m, 1)
 				}
-				
 				// check if the desired date is within the range of our defined startDate and endDate
 				if (t.getTime() < s.getTime()) {
 					t = s;
 				} else if (t.getTime() > e.getTime()) {
 					t = e;
 				}
+				var oldMonth = this.displayedMonth;
+				var oldYear = this.displayedYear;
 				this.displayedMonth = t.getMonth();
 				this.displayedYear = t.getFullYear();
+
+				if (rerender && (this.displayedMonth != oldMonth || this.displayedYear != oldYear))
+				{
+					this._rerenderCalendar();
+					$(this.ele).trigger('dpMonthChanged', [this.displayedMonth, this.displayedYear]);
+				}
 			},
-			setSelected : function(d, v, moveToMonth)
+			setSelected : function(d, v, moveToMonth, dispatchEvents)
 			{
+				if (d < this.startDate || d.zeroTime() > this.endDate.zeroTime()) {
+					// Don't allow people to select dates outside range...
+					return;
+				}
+				var s = this.settings;
+				if (s.selectWeek)
+				{
+					d = d.addDays(- (d.getDay() - Date.firstDayOfWeek + 7) % 7);
+					if (d < this.startDate) // The first day of this week is before the start date so is unselectable...
+					{
+						return;
+					}
+				}
+				if (v == this.isSelected(d)) // this date is already un/selected
+				{
+					return;
+				}
 				if (this.selectMultiple == false) {
-					this.selectedDates = {};
-					$('td.selected', this.context).removeClass('selected');
+					this.clearSelected();
+				} else if (v && this.numSelected == this.numSelectable) {
+					// can't select any more dates...
+					return;
 				}
-				if (moveToMonth) {
-					this.setDisplayedMonth(d.getMonth(), d.getFullYear());
+				if (moveToMonth && (this.displayedMonth != d.getMonth() || this.displayedYear != d.getFullYear())) {
+					this.setDisplayedMonth(d.getMonth(), d.getFullYear(), true);
 				}
-				this.selectedDates[d.toString()] = v;
+				this.selectedDates[d.asString()] = v;
+				this.numSelected += v ? 1 : -1;
+				var selectorString = 'td.' + (d.getMonth() == this.displayedMonth ? 'current-month' : 'other-month');
+				var $td;
+				$(selectorString, this.context).each(
+					function()
+					{
+						if ($(this).data('datePickerDate') == d.asString()) {
+							$td = $(this);
+							if (s.selectWeek)
+							{
+								$td.parent()[v ? 'addClass' : 'removeClass']('selectedWeek');
+							}
+							$td[v ? 'addClass' : 'removeClass']('selected');
+						}
+					}
+				);
+				$('td', this.context).not('.selected')[this.selectMultiple &&  this.numSelected == this.numSelectable ? 'addClass' : 'removeClass']('unselectable');
+
+				if (dispatchEvents)
+				{
+					var s = this.isSelected(d);
+					$e = $(this.ele);
+					var dClone = Date.fromString(d.asString());
+					$e.trigger('dateSelected', [dClone, $td, s]);
+					$e.trigger('change');
+				}
 			},
 			isSelected : function(d)
 			{
-				return this.selectedDates[d.toString()];
+				return this.selectedDates[d.asString()];
 			},
 			getSelected : function()
 			{
 				var r = [];
-				for(s in this.selectedDates) {
+				for(var s in this.selectedDates) {
 					if (this.selectedDates[s] == true) {
-						r.push(Date.parse(s));
+						r.push(Date.fromString(s));
 					}
 				}
 				return r;
 			},
+			clearSelected : function()
+			{
+				this.selectedDates = {};
+				this.numSelected = 0;
+				$('td.selected', this.context).removeClass('selected').parent().removeClass('selectedWeek');
+			},
 			display : function(eleAlignTo)
 			{
 				if ($(this.ele).is('.dp-disabled')) return;
-				
+
 				eleAlignTo = eleAlignTo || this.ele;
 				var c = this;
 				var $ele = $(eleAlignTo);
 				var eleOffset = $ele.offset();
-				
+
 				var $createIn;
 				var attrs;
 				var attrsCalendarHolder;
 				var cssRules;
-				
+
 				if (c.inline) {
 					$createIn = $(this.ele);
 					attrs = {
 						'id'		:	'calendar-' + this.ele._dpId,
 						'class'	:	'dp-popup dp-popup-inline'
 					};
+
+					$('.dp-popup', $createIn).remove();
 					cssRules = {
 					};
 				} else {
@@ -722,12 +802,12 @@
 						'top'	:	eleOffset.top + c.verticalOffset,
 						'left'	:	eleOffset.left + c.horizontalOffset
 					};
-					
+
 					var _checkMouse = function(e)
 					{
 						var el = e.target;
 						var cal = $('#dp-popup')[0];
-						
+
 						while (true){
 							if (el == cal) {
 								return true;
@@ -740,17 +820,35 @@
 						}
 					};
 					this._checkMouse = _checkMouse;
-				
-					this._closeCalendar(true);
+
+					c._closeCalendar(true);
+					$(document).bind(
+						'keydown.datepicker',
+						function(event)
+						{
+							if (event.keyCode == 27) {
+								c._closeCalendar();
+							}
+						}
+					);
 				}
-				
-				
+
+				if (!c.rememberViewedMonth)
+				{
+					var selectedDate = this.getSelected()[0];
+					if (selectedDate) {
+						selectedDate = new Date(selectedDate);
+						this.setDisplayedMonth(selectedDate.getMonth(), selectedDate.getFullYear(), false);
+					}
+				}
+
 				$createIn
 					.append(
 						$('<div></div>')
 							.attr(attrs)
 							.css(cssRules)
 							.append(
+//								$('<a href="#" class="selecteee">aaa</a>'),
 								$('<h2></h2>'),
 								$('<div class="dp-nav-prev"></div>')
 									.append(
@@ -790,14 +888,13 @@
 												}
 											)
 									),
-								$('<div></div>')
-									.attr('class', 'dp-calendar')
+								$('<div class="dp-calendar"></div>')
 							)
 							.bgIframe()
 						);
-					
+
 				var $pop = this.inline ? $('.dp-popup', this.context) : $('#dp-popup');
-				
+
 				if (this.showYearNavigation == false) {
 					$('.dp-nav-prev-year, .dp-nav-next-year', c.context).css('display', 'none');
 				}
@@ -815,9 +912,9 @@
 					);
 				}
 				c._renderCalendar();
-				
+
 				$(this.ele).trigger('dpDisplayed', $pop);
-				
+
 				if (!c.inline) {
 					if (this.verticalPosition == $.dpConst.POS_BOTTOM) {
 						$pop.css('top', eleOffset.top + $ele.height() - $pop.height() + c.verticalOffset);
@@ -825,11 +922,14 @@
 					if (this.horizontalPosition == $.dpConst.POS_RIGHT) {
 						$pop.css('left', eleOffset.left + $ele.width() - $pop.width() + c.horizontalOffset);
 					}
-					$(document).bind('mousedown', this._checkMouse);
+//					$('.selectee', this.context).focus();
+					$(document).bind('mousedown.datepicker', this._checkMouse);
 				}
+
 			},
 			setRenderCallback : function(a)
 			{
+				if (a == null) return;
 				if (a && typeof(a) == 'function') {
 					a = [a];
 				}
@@ -838,68 +938,102 @@
 			cellRender : function ($td, thisDate, month, year) {
 				var c = this.dpController;
 				var d = new Date(thisDate.getTime());
-				
+
 				// add our click handlers to deal with it when the days are clicked...
-				
+
 				$td.bind(
 					'click',
 					function()
 					{
 						var $this = $(this);
 						if (!$this.is('.disabled')) {
-							c.setSelected(d, !$this.is('.selected') || !c.selectMultiple);
-							var s = c.isSelected(d);
-							$(c.ele).trigger('dateSelected', [d, $td, s]);
-							$(c.ele).trigger('change');
+							c.setSelected(d, !$this.is('.selected') || !c.selectMultiple, false, true);
 							if (c.closeOnSelect) {
+								// Focus the next input in the form…
+								if (c.settings.autoFocusNextInput) {
+									var ele = c.ele;
+									var found = false;
+									$(':input', ele.form).each(
+										function()
+										{
+											if (found) {
+												$(this).focus();
+												return false;
+											}
+											if (this == ele) {
+												found = true;
+											}
+										}
+									);
+								} else {
+									try {
+										c.ele.focus();
+									} catch (e) {}
+								}
 								c._closeCalendar();
-							} else {
-								$this[s ? 'addClass' : 'removeClass']('selected');
 							}
 						}
 					}
 				);
-				
 				if (c.isSelected(d)) {
 					$td.addClass('selected');
+					if (c.settings.selectWeek)
+					{
+						$td.parent().addClass('selectedWeek');
+					}
+				} else  if (c.selectMultiple && c.numSelected == c.numSelectable) {
+					$td.addClass('unselectable');
 				}
-				
-				// call any extra renderCallbacks that were passed in
-				for (var i=0; i<c.renderCallback.length; i++) {
-					c.renderCallback[i].apply(this, arguments);
-				}
-				
-				
+
+			},
+			_applyRenderCallbacks : function()
+			{
+				var c = this;
+				$('td', this.context).each(
+					function()
+					{
+						for (var i=0; i<c.renderCallback.length; i++) {
+							$td = $(this);
+							c.renderCallback[i].apply(this, [$td, Date.fromString($td.data('datePickerDate')), c.displayedMonth, c.displayedYear]);
+						}
+					}
+				);
+				return;
 			},
 			// ele is the clicked button - only proceed if it doesn't have the class disabled...
 			// m and y are -1, 0 or 1 depending which direction we want to go in...
-			_displayNewMonth : function(ele, m, y) 
+			_displayNewMonth : function(ele, m, y)
 			{
 				if (!$(ele).is('.disabled')) {
-					this.setDisplayedMonth(this.displayedMonth + m, this.displayedYear + y);
-					this._clearCalendar();
-					this._renderCalendar();
-					$(this.ele).trigger('dpMonthChanged', [this.displayedMonth, this.displayedYear]);
+					this.setDisplayedMonth(this.displayedMonth + m, this.displayedYear + y, true);
 				}
 				ele.blur();
 				return false;
 			},
+			_rerenderCalendar : function()
+			{
+				this._clearCalendar();
+				this._renderCalendar();
+			},
 			_renderCalendar : function()
 			{
 				// set the title...
-				$('h2', this.context).html(Date.monthNames[this.displayedMonth] + ' ' + this.displayedYear);
-				
+				$('h2', this.context).html((new Date(this.displayedYear, this.displayedMonth, 1)).asString($.dpText.HEADER_FORMAT));
+
 				// render the calendar...
 				$('.dp-calendar', this.context).renderCalendar(
-					{
-						month			: this.displayedMonth,
-						year			: this.displayedYear,
-						renderCallback	: this.cellRender,
-						dpController	: this,
-						hoverClass		: this.hoverClass
-					}
+					$.extend(
+						{},
+						this.settings,
+						{
+							month			: this.displayedMonth,
+							year			: this.displayedYear,
+							renderCallback	: this.cellRender,
+							dpController	: this,
+							hoverClass		: this.hoverClass
+						})
 				);
-				
+
 				// update the status of the control buttons and disable dates before startDate or after endDate...
 				// TODO: When should the year buttons be disabled? When you can't go forward a whole year from where you are or is that annoying?
 				if (this.displayedYear == this.startDate.getFullYear() && this.displayedMonth == this.startDate.getMonth()) {
@@ -930,14 +1064,15 @@
 					var d = this.startDate.getDate();
 					if (d > 20) {
 						// check if the startDate is last month as we might need to add some disabled classes...
-						var sd = new Date(this.startDate.getTime());
+						var st = this.startDate.getTime();
+						var sd = new Date(st);
 						sd.addMonths(1);
 						if (this.displayedYear == sd.getFullYear() && this.displayedMonth == sd.getMonth()) {
-							$('dp-calendar td.other-month', this.context).each(
+							$('.dp-calendar td.other-month', this.context).each(
 								function()
 								{
 									var $this = $(this);
-									if (Number($this.text()) < d) {
+									if (Date.fromString($this.data('datePickerDate')).getTime() < st) {
 										$this.addClass('disabled');
 									}
 								}
@@ -980,7 +1115,8 @@
 								function()
 								{
 									var $this = $(this);
-									if (Number($this.text()) > d) {
+									var cellDay = Number($this.text());
+									if (cellDay < 13 && cellDay > d) {
 										$this.addClass('disabled');
 									}
 								}
@@ -988,12 +1124,14 @@
 						}
 					}
 				}
+				this._applyRenderCallbacks();
 			},
 			_closeCalendar : function(programatic, ele)
 			{
 				if (!ele || ele == this.ele)
 				{
-					$(document).unbind('mousedown', this._checkMouse);
+					$(document).unbind('mousedown.datepicker');
+					$(document).unbind('keydown.datepicker');
 					this._clearCalendar();
 					$('#dp-popup a').unbind();
 					$('#dp-popup').empty().remove();
@@ -1012,7 +1150,7 @@
 			}
 		}
 	);
-	
+
 	// static constants
 	$.dpConst = {
 		SHOW_HEADER_NONE	:	0,
@@ -1021,7 +1159,8 @@
 		POS_TOP				:	0,
 		POS_BOTTOM			:	1,
 		POS_LEFT			:	0,
-		POS_RIGHT			:	1
+		POS_RIGHT			:	1,
+		DP_INTERNAL_FOCUS	:	'dpInternalFocusTrigger'
 	};
 	// localisable text
 	$.dpText = {
@@ -1031,16 +1170,42 @@
 		TEXT_NEXT_MONTH		:	_("Next month"),
 		TEXT_CLOSE			:	_("Close"),
 		TEXT_CHOOSE_DATE	:	_("Choose date"),
+		HEADER_FORMAT		:	'mmmm yyyy'
 	};
 	// version
-	$.dpVersion = '$Id: jquery.datePicker.js 3739 2007-10-25 13:55:30Z kelvin.luck $';
+	$.dpVersion = '$Id$';
+
+	$.fn.datePicker.defaults = {
+		month				: undefined,
+		year				: undefined,
+		showHeader			: $.dpConst.SHOW_HEADER_SHORT,
+		startDate			: undefined,
+		endDate				: undefined,
+		inline				: false,
+		renderCallback		: null,
+		createButton		: true,
+		showYearNavigation	: true,
+		closeOnSelect		: true,
+		displayClose		: false,
+		selectMultiple		: false,
+		numSelectable		: Number.MAX_VALUE,
+		clickInput			: false,
+		rememberViewedMonth	: true,
+		selectWeek			: false,
+		verticalPosition	: $.dpConst.POS_TOP,
+		horizontalPosition	: $.dpConst.POS_LEFT,
+		verticalOffset		: 0,
+		horizontalOffset	: 0,
+		hoverClass			: 'dp-hover',
+		autoFocusNextInput  : false
+	};
 
 	function _getController(ele)
 	{
 		if (ele._dpId) return $.event._dpCache[ele._dpId];
 		return false;
 	};
-	
+
 	// make it so that no error is thrown if bgIframe plugin isn't included (allows you to use conditional
 	// comments to only include bgIframe where it is needed in IE without breaking this plugin).
 	if ($.fn.bgIframe == undefined) {
@@ -1056,12 +1221,6 @@
 				$(els[i].ele)._dpDestroy();
 			}
 		});
-		
-	
+
+
 })(jQuery);
-$(document).ready(function(){
-	$('input.date').datePicker({clickInput:true,startDate:'01/01/1970'}).attr('autocomplete','off').each(function(){
-		var placeholder=$(this).attr('placeholder');
-		$(this).attr('placeholder',placeholder+((placeholder && placeholder.length)>0?' - ':'')+'Click for calendar');
-	});
-});

--- a/js/plugins/jquery.datePicker-patched-for-i18n.js
+++ b/js/plugins/jquery.datePicker-patched-for-i18n.js
@@ -1025,12 +1025,12 @@
 	};
 	// localisable text
 	$.dpText = {
-		TEXT_PREV_YEAR		:	'Previous year',
-		TEXT_PREV_MONTH		:	'Previous month',
-		TEXT_NEXT_YEAR		:	'Next year',
-		TEXT_NEXT_MONTH		:	'Next month',
-		TEXT_CLOSE			:	'Close',
-		TEXT_CHOOSE_DATE	:	'Choose date'
+		TEXT_PREV_YEAR		:	_("Previous year"),
+		TEXT_PREV_MONTH		:	_("Previous month"),
+		TEXT_NEXT_YEAR		:	_("Next year"),
+		TEXT_NEXT_MONTH		:	_("Next month"),
+		TEXT_CLOSE			:	_("Close"),
+		TEXT_CHOOSE_DATE	:	_("Choose date"),
 	};
 	// version
 	$.dpVersion = '$Id: jquery.datePicker.js 3739 2007-10-25 13:55:30Z kelvin.luck $';

--- a/resources/resource.php
+++ b/resources/resource.php
@@ -43,18 +43,8 @@ if ((isset($_GET['ref'])) && ($_GET['ref'] == 'new')){
 
 //set this to turn off displaying the title header in header.php
 $pageTitle=$resource->titleText;
-$customJSInclude =  '<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>' . "\n";
-$customJSInclude =  '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">' . "\n";
-$customJSInclude .= '<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>' . "\n";
-
-$customJSInclude .= '<script type="text/javascript" src="../js/plugins/jquery.autocomplete.js"></script>' . "\n";
-$customJSInclude .= '<script type="text/javascript" src="../js/plugins/datejs-patched-for-i18n.js"></script>' . "\n";
-$customJSInclude .= '<script type="text/javascript" src="../js/plugins/jquery.datePicker-patched-for-i18n.js"></script>' . "\n";
-$customJSInclude .= '<script type="text/javascript" src="../js/common.js"></script>' . "\n";
-$customJSInclude .= '<script type="text/javascript" src="js/common.js"></script>' . "\n";
 
 include 'templates/header.php';
-
 
 if ($resource->titleText){
 	?>


### PR DESCRIPTION
This PR:

- Resolves #747 
- Removes redundant loading of javascripts from resource.php that have already been loaded in [header.php](https://github.com/coral-erm/coral/blob/ERM-63-modern-jquery-update-with-php8/resources/templates/header.php#L54)
- Restores the i18n keys to the datepicker plugin
- Updates the datepicker plugin to use the latest version from the original author: http://2008.kelvinluck.com/assets/jquery/datePicker/v2/demo/scripts/jquery.datePicker.js
- Attempts some code formatting cleanup

The latest, original version of the plugin appears to include all the modern jquery updates that were provided by the forked version along with additional improvements and fixes. I haven't found any issues testing these changes locally.