### PR TITLE
Managment - Re-load datepickers after modal instantiation

### DIFF
--- a/management/js/common.js
+++ b/management/js/common.js
@@ -241,8 +241,10 @@ function myDialog(loadForm, h,w){
             modal: true,
             open: function ()
             {
-            if ($(this).is(':empty')) {
-                $(this).load(loadForm);
+                if ($(this).is(':empty')) {
+                    $(this).load(loadForm, function() {
+                        loadDatePicker();
+                    });
                 }
             },
             height: h,


### PR DESCRIPTION
In the management module, the datepickers were being initialized once on page load. This meant that datepickers in async loaded modals never got initialized.

This PR re-executes the datepicker initializer immediately after a modal is loaded to properly register any datepickers it might have added to the dom.

Before:

![management-without-datepicker](https://github.com/coral-erm/coral/assets/5373296/5dbcfb8b-050d-4655-acc8-12e99ea111d3)

After:

![management-with-datepicker](https://github.com/coral-erm/coral/assets/5373296/0c59d00e-40a4-4546-8b4b-947a052e9188)
