### PR TITLE
Do not process URLs passed directly from users

### DIFF
--- a/usage/admin/classes/common/Utility.php
+++ b/usage/admin/classes/common/Utility.php
@@ -118,26 +118,32 @@ class Utility {
 
 	static public function utf8_fopen_read($fileName, $isSushiFile) {
 
+		$handle=fopen("php://memory", "rw");
+
+		// If we were passed a URL, just send back an empty file handle.
+		if (preg_match("/^[^:]+:\/\//", $fileName)){ // starts with a URL scheme...
+			return $handle;
+		}
+
 		//if the string isn't already ut8
 		if ($isSushiFile){
 			$fc = file_get_contents($fileName);
 		}else{
-      $fc = file_get_contents($fileName);
-      // remove a UTF-8 BOM
-      if(substr($fc,0,3)==chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
-        $fc = substr($fc,3);
-      } else {
-        $fc = iconv('windows-1250', 'utf-8', file_get_contents($fileName));
-        if(empty($fc)){
-          $fc = mb_convert_encoding(file_get_contents($fileName),'utf-8');
-        }
-      }
+			$fc = file_get_contents($fileName);
+			// remove a UTF-8 BOM
+			if(substr($fc,0,3)==chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
+				$fc = substr($fc,3);
+			} else {
+				$fc = iconv('windows-1250', 'utf-8', file_get_contents($fileName));
+				if(empty($fc)){
+					$fc = mb_convert_encoding(file_get_contents($fileName),'utf-8');
+				}
+			}
 		}
 
-    $handle=fopen("php://memory", "rw");
-    fwrite($handle, $fc);
-    fseek($handle, 0);
-    return $handle;
+		fwrite($handle, $fc);
+		fseek($handle, 0);
+		return $handle;
 	}
 
 }


### PR DESCRIPTION
SUSHI statistics can be retreived from a stored URL, but those are downloaded locally before being processed by the uploadComplete.php script. Because of that, we can simply refuse to load data from URLs using the (local) utf8_fopen_read function, which is only used to load server-local files into memory for processing.