### PR TITLE
Protect against non-numeric taxRate value

### DIFF
--- a/resources/ajax_processing/submitCost.php
+++ b/resources/ajax_processing/submitCost.php
@@ -33,7 +33,7 @@
 					$resourcePayment->subscriptionEndDate   = $end;
 					$resourcePayment->fundID        = $fundIDArray[$key];
 					$resourcePayment->priceTaxExcluded = $pteArray[$key];
-					$resourcePayment->taxRate       = $taxRateArray[$key];
+					$resourcePayment->taxRate       = is_numeric($taxRateArray[$key]) ? $taxRateArray[$key] : null;
 					$resourcePayment->priceTaxIncluded = $ptiArray[$key];
 					$resourcePayment->paymentAmount = $paymentAmountArray[$key];
 					$resourcePayment->currencyCode  = $currencyCodeArray[$key];


### PR DESCRIPTION
Newer MySQL/MariaDB versions are more strict about type restrictions, and do not like to coerce an empty string to NULL on a numeric column type.  Here we make sure that non-numeric user input is dropped, and NULL is stored when a number isn't passed to the input form.