### PR TITLE
Fix empty string sql error for local archived contacts

### DIFF
--- a/resources/admin/classes/domain/ResourceAcquisition.php
+++ b/resources/admin/classes/domain/ResourceAcquisition.php
@@ -708,7 +708,7 @@ class ResourceAcquisition extends DatabaseObject {
 		//get resource specific contacts
 		$query = "SELECT C.*, GROUP_CONCAT(CR.shortName SEPARATOR '<br /> ') contactRoles
 			FROM Contact C, ContactRole CR, ContactRoleProfile CRP
-			WHERE (archiveDate != '0000-00-00' && archiveDate != '')
+			WHERE (archiveDate != '0000-00-00' && archiveDate is not null)
 			AND C.contactID = CRP.contactID
 			AND CRP.contactRoleID = CR.contactRoleID
 			AND resourceAcquisitionID = '" . $this->resourceAcquisitionID . "'


### PR DESCRIPTION
This fixes a similar issue to a [previous fix](https://github.com/coral-erm/coral/pull/727/changes#diff-6e2ca85e31cfcf10956badc61de0a320f0da35814bc46fcf5e642a5ec59b4662L266) for Organization contacts; this time for Resource contacts.

The Resource Contacts tab fails to load the archived contacts for a given resource when recent Mysql/MariaDB versions are being used.

The Contacts tab will show the 'refreshing contents' loading message indefinitely:
<img width="1225" height="873" alt="resource-refreshing-contents" src="https://github.com/user-attachments/assets/5dbd8e49-a4b3-4f54-abb4-db7df96b46c3" />

Because this AJAX request: https://[yourdomain]/resources/ajax_htmldata.php?action=getContactDetails&resourceID=3117&resourceAcquisitionID=3192&archiveInd=1&showArchivesInd=0
 
 Failed due to this 500 error:
 
> PHP Fatal error:  Uncaught mysqli_sql_exception: Incorrect DATE value: '' in /var/www/html/resources/admin/classes/common/DBService.php:90\nStack trace:\n#0 /var/www/html/resources/admin/classes/common/DBService.php(90): mysqli->query()\n#1 /var/www/html/resources/admin/classes/domain/ResourceAcquisition.php(718): DBService->processQuery()\n#2 /var/www/html/resources/ajax_htmldata/getContactDetails.php(183): ResourceAcquisition->getArchivedContacts()\n#3 /var/www/html/resources/ajax_htmldata.php(24): include('...')\n#4 {main}\n  thrown in /var/www/html/resources/admin/classes/common/DBService.php on line 90, referer: [yourdomain]/resources/resource.php?resourceID=1&showTab=contacts

I've matched the casing in the SQL to the existing style for the similar query on line 678 in the ResourceAcquisition file.